### PR TITLE
Adding Python 3.8 to environment matrix.

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-16.04, windows-latest, macos-latest]
         # Run with and without psutil installed.
         env:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ TaskGraph Release History
 Unreleased Changes
 ------------------
 * Updating primary repo url to Github.
+* Adding support for Python 3.8.
 
 0.8.5 (2019-09-11)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'License :: OSI Approved :: BSD License'
     ])

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -52,19 +52,32 @@ _MAX_TIMEOUT = 5.0  # amount of time to wait for threads to terminate
 # https://stackoverflow.com/a/8963618/42897
 class NoDaemonProcess(multiprocessing.Process):
     """Make 'daemon' attribute always return False."""
-
+    """
     def _get_daemon(self):
         return False
 
     def _set_daemon(self, value):
         pass
-    daemon = property(_get_daemon, _set_daemon)
 
+    """
+    @property
+    def daemon(self):
+        return False
+    @daemon.setter
+    def daemon(self, value):
+        pass
+    #daemon = property(_get_daemon, _set_daemon)
+
+class NoDaemonContext(type(multiprocessing.get_context('spawn'))):
+    Process = NoDaemonProcess
 
 class NonDaemonicPool(multiprocessing.pool.Pool):
     """NonDaemonic Process Pool."""
 
-    Process = NoDaemonProcess
+    #Process = NoDaemonProcess
+    def __init__(self, *args, **kwargs):
+        kwargs['context'] = NoDaemonContext()
+        super(NonDaemonicPool, self).__init__(*args, **kwargs)
 
 
 def _initialize_logging_to_queue(logging_queue):

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -52,29 +52,21 @@ _MAX_TIMEOUT = 5.0  # amount of time to wait for threads to terminate
 # https://stackoverflow.com/a/8963618/42897
 class NoDaemonProcess(multiprocessing.Process):
     """Make 'daemon' attribute always return False."""
-    """
-    def _get_daemon(self):
-        return False
-
-    def _set_daemon(self, value):
-        pass
-
-    """
     @property
     def daemon(self):
         return False
     @daemon.setter
     def daemon(self, value):
         pass
-    #daemon = property(_get_daemon, _set_daemon)
+
 
 class NoDaemonContext(type(multiprocessing.get_context('spawn'))):
     Process = NoDaemonProcess
 
+
 class NonDaemonicPool(multiprocessing.pool.Pool):
     """NonDaemonic Process Pool."""
 
-    #Process = NoDaemonProcess
     def __init__(self, *args, **kwargs):
         kwargs['context'] = NoDaemonContext()
         super(NonDaemonicPool, self).__init__(*args, **kwargs)

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -61,6 +61,13 @@ class NoDaemonProcess(multiprocessing.Process):
         pass
 
 
+# From https://stackoverflow.com/a/8963618/42897
+# "As the current implementation of multiprocessing [3.7+] has been extensively 
+# refactored to be based on contexts, we need to provide a NoDaemonContext
+# class that has our NoDaemonProcess as attribute. [NonDaemonicPool] will then 
+# use that context instead of the default one." 
+# "spawn" is chosen as default since that is the default and only context 
+# option for Windows and is the default option for Mac OS as well since 3.8.
 class NoDaemonContext(type(multiprocessing.get_context('spawn'))):
     Process = NoDaemonProcess
 
@@ -68,6 +75,7 @@ class NoDaemonContext(type(multiprocessing.get_context('spawn'))):
 class NonDaemonicPool(multiprocessing.pool.Pool):
     """NonDaemonic Process Pool."""
 
+    # Inovking super to set the context of Pool class explicitly
     def __init__(self, *args, **kwargs):
         kwargs['context'] = NoDaemonContext()
         super(NonDaemonicPool, self).__init__(*args, **kwargs)

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -55,6 +55,7 @@ class NoDaemonProcess(multiprocessing.Process):
     @property
     def daemon(self):
         return False
+
     @daemon.setter
     def daemon(self, value):
         pass


### PR DESCRIPTION
Addressing issue #7 with regards to adding python 3.8 support.

This PR provides support for Python 3.8 in so far that the tests for taskgraph pass for 3.6, 3.7, and 3.8. It has not been tested in conjuncture with InVEST. 

An error that occurred when testing python 3.8 was an assertion error in multiprocessing.process for group being set to none for now. This was likely due to the multiprocessing pool.pool class not properly being constructed when sub-classed. See this SO post and the subsequent answers below the accepted answer: 
https://stackoverflow.com/a/8963618/42897

This PR also changes has daemon getter and setter are handled, which I believe is an accepted standard.