### PR TITLE
Remove ABC, paramaterize database access, and remove locks.

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -20,7 +20,7 @@ jobs:
             - EXTRAPKGS:
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,9 @@ Unreleased Changes
 ------------------
 * Updating primary repo url to Github.
 * Adding support for Python 3.8.
+* Removing the ``EncapsulatedOp`` abstract class. In practice the development
+  loop that encouraged the use of ``EncapsulatedOp`` is flawed and can lead to
+  design errors.
 
 0.8.5 (2019-09-11)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ Unreleased Changes
 * Removing unnecessary internal locks which will improve runtime performance of
   processing many small Tasks.
 * Refactor to support separate TaskGraph objects that use the same database.
+* Removed the ``n_retries`` parameter from ``add_task``. Users are recommended
+  to handle retries within functions themselves.
 
 0.8.5 (2019-09-11)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,9 @@ Unreleased Changes
 * Removing the ``EncapsulatedOp`` abstract class. In practice the development
   loop that encouraged the use of ``EncapsulatedOp`` is flawed and can lead to
   design errors.
+* Removing unnecessary internal locks which will improve runtime performance of
+  processing many small Tasks.
+* Refactor to support separate TaskGraph objects that use the same database.
 
 0.8.5 (2019-09-11)
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
-# no external requirements for TaskGraph needed
+# requirements.txt
+# --------------------
+# This file records the packages and requirements needed in order for
+# taskgraph to work as expected.
+
+retrying>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 """taskgraph setup.py."""
 from setuptools import setup
 
+
+_REQUIREMENTS = [
+    x for x in open('requirements.txt').read().split('\n')
+    if not x.startswith('#') and len(x) > 0]
+
 LONG_DESCRIPTION = '%s\n\n%s' % (
     open('README.rst').read(),
     open('HISTORY.rst').read())
@@ -18,6 +23,7 @@ setup(
     packages=['taskgraph'],
     license='BSD',
     keywords='parallel multiprocessing distributed computing',
+    install_requires=_REQUIREMENTS,
     extras_require={
         'niced_processes': ['psutil'],
         },

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -20,12 +20,6 @@ import time
 
 
 _VALID_PATH_TYPES = (str, pathlib.Path)
-# Superclass for ABCs, compatible with python 2.7+ that replaces __metaclass__
-# usage that is no longer clearly documented in python 3 (if it's even present
-# at all ... __metaclass__ has been removed from the python data model docs)
-# Taken from https://stackoverflow.com/a/38668373/299084
-ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
-
 _TASKGRAPH_DATABASE_FILENAME = 'taskgraph_data.db'
 
 try:
@@ -62,11 +56,11 @@ class NoDaemonProcess(multiprocessing.Process):
 
 
 # From https://stackoverflow.com/a/8963618/42897
-# "As the current implementation of multiprocessing [3.7+] has been extensively 
+# "As the current implementation of multiprocessing [3.7+] has been extensively
 # refactored to be based on contexts, we need to provide a NoDaemonContext
-# class that has our NoDaemonProcess as attribute. [NonDaemonicPool] will then 
-# use that context instead of the default one." 
-# "spawn" is chosen as default since that is the default and only context 
+# class that has our NoDaemonProcess as attribute. [NonDaemonicPool] will then
+# use that context instead of the default one."
+# "spawn" is chosen as default since that is the default and only context
 # option for Windows and is the default option for Mac OS as well since 3.8.
 class NoDaemonContext(type(multiprocessing.get_context('spawn'))):
     Process = NoDaemonProcess

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -354,7 +354,7 @@ class TaskGraph(object):
                 LOGGER.debug(
                     "taskgraph is terminated, ending %s",
                     threading.currentThread())
-                return
+                break
             task = None
             try:
                 task = self._task_ready_priority_queue.get_nowait()
@@ -372,7 +372,7 @@ class TaskGraph(object):
                         "no tasks are pending and taskgraph closed, normally "
                         "terminating executor %s." %
                         threading.currentThread())
-                    return
+                    break
                 else:
                     self._executor_ready_event.clear()
             if task is None:
@@ -387,7 +387,7 @@ class TaskGraph(object):
                     'A taskgraph _task_executor failed on Task '
                     '%s. Terminating taskgraph.', task.task_name)
                 self._terminate()
-                return
+                break
 
             LOGGER.debug(
                 "task %s is complete, checking to see if any dependent "
@@ -1066,9 +1066,6 @@ class Task(object):
         # in args and kwargs but ignores anything specifically targeted or
         # an expected result. This will allow a task to change its hash in
         # case a different version of a file was passed in.
-        if self._precalculated is not None:
-            return self._precalculated
-
         # these are the stats of the files that exist that aren't ignored
         file_stat_list = list(_get_file_stats(
             [self._args, self._kwargs],
@@ -1114,7 +1111,6 @@ class Task(object):
                 LOGGER.debug("is_precalculated full task info: %s", self)
                 self._precalculated = False
                 return False
-            LOGGER.debug('reexecution database result: %s', pickle.loads(database_result[0]))
             result_target_path_stats = pickle.loads(database_result[0])
             mismatched_target_file_list = []
             for path, hash_algorithm, hash_string in result_target_path_stats:

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1,5 +1,4 @@
 """Task graph framework."""
-import abc
 import collections
 import hashlib
 import inspect

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1228,35 +1228,6 @@ class Task(object):
         return timed_out
 
 
-class EncapsulatedTaskOp(ABC):
-    """Used as a superclass for Task operations that need closures.
-
-    This class will automatically hash the subclass's __call__ method source
-    as well as the arguments to its __init__ function to calculate the
-    Task's unique hash.
-
-    """
-
-    def __init__(self, *args, **kwargs):
-        """Attempt to get the source code of __call__."""
-        args_as_str = str([args, kwargs]).encode('utf-8')
-        try:
-            # hash the args plus source code of __call__
-            id_hash = hashlib.sha1(args_as_str + inspect.getsource(
-                self.__class__.__call__).encode('utf-8')).hexdigest()
-        except IOError:
-            # this will fail if the code is compiled, that's okay just do
-            # the args
-            id_hash = hashlib.sha1(args_as_str)
-        # prefix the classname
-        self.__name__ = '%s_%s' % (self.__class__.__name__, id_hash)
-
-    @abc.abstractmethod
-    def __call__(self, *args, **kwargs):
-        """Empty method meant to be overridden by inheritor."""
-        pass
-
-
 def _get_file_stats(
         base_value, hash_algorithm, ignore_list, ignore_directories):
     """Return fingerprints of any filepaths in `base_value`.

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1383,6 +1383,8 @@ def _execute_sqlite(
     Parameters:
         sqlite_command (str): a well formatted SQLite command.
         database_path (str): path to the SQLite database to operate on.
+        argument_list (list): `execute == 'execute` then this list is passed to
+            the internal sqlite3 `execute` call.
         mode (str): must be either 'read_only' or 'modify'.
         execute (str): must be either 'execute' or 'script'.
         fetch (str): if not `None` can be either 'all' or 'one'.

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -184,9 +184,6 @@ class TaskGraph(object):
         # this lock is used to synchronize the following objects
         self._taskgraph_lock = threading.RLock()
 
-        # this is used to guard multiple connections to the same database
-        self._task_database_lock = threading.Lock()
-
         # this might hold the threads to execute tasks if n_workers >= 0
         self._task_executor_thread_list = []
 
@@ -537,7 +534,7 @@ class TaskGraph(object):
                     self._worker_pool, self._taskgraph_cache_dir_path,
                     priority, hash_algorithm, copy_duplicate_artifact,
                     self._taskgraph_started_event,
-                    self._task_database_path, self._task_database_lock)
+                    self._task_database_path)
 
                 self._task_name_map[new_task.task_name] = new_task
                 # it may be this task was already created in an earlier call,
@@ -760,7 +757,7 @@ class Task(object):
             ignore_path_list, ignore_directories,
             worker_pool, cache_dir, priority, hash_algorithm,
             copy_duplicate_artifact, taskgraph_started_event,
-            task_database_path, task_database_lock):
+            task_database_path):
         """Make a Task.
 
         Parameters:
@@ -810,8 +807,6 @@ class Task(object):
                 table and the target_path_stats stores the base/target stats
                 for the target files created by the call and listed in
                 `target_path_list`.
-            task_database_lock (threading.Lock): used to lock the task
-                database before a .connect.
 
         """
         # it is a common error to accidentally pass a non string as to the
@@ -840,7 +835,6 @@ class Task(object):
         self._task_database_path = task_database_path
         self._hash_algorithm = hash_algorithm
         self._copy_duplicate_artifact = copy_duplicate_artifact
-        self._task_database_lock = task_database_lock
         self.exception_object = None
 
         # This flag is used to avoid repeated calls to "is_precalculated"

--- a/taskgraph/__init__.py
+++ b/taskgraph/__init__.py
@@ -1,6 +1,9 @@
 """TaskGraph init module."""
+from pkg_resources import get_distribution
+
 from .Task import TaskGraph
 from .Task import Task
 from .Task import _TASKGRAPH_DATABASE_FILENAME
 
 __all__ = ['TaskGraph', 'Task', '_TASKGRAPH_DATABASE_FILENAME']
+__version__ = get_distribution(__name__).version

--- a/taskgraph/__init__.py
+++ b/taskgraph/__init__.py
@@ -1,5 +1,6 @@
 """TaskGraph init module."""
 from .Task import TaskGraph
 from .Task import Task
+from .Task import _TASKGRAPH_DATABASE_FILENAME
 
-__all__ = ['TaskGraph', 'Task']
+__all__ = ['TaskGraph', 'Task', '_TASKGRAPH_DATABASE_FILENAME']

--- a/taskgraph/__init__.py
+++ b/taskgraph/__init__.py
@@ -1,27 +1,6 @@
 """taskgraph module."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-import pkg_resources
 from .Task import (
     TaskGraph, Task, EncapsulatedTaskOp, _TASKGRAPH_DATABASE_FILENAME)
 
 __all__ = [
     'TaskGraph', 'Task', 'EncapsulatedTaskOp', '_TASKGRAPH_DATABASE_FILENAME']
-
-
-try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-except pkg_resources.DistributionNotFound:
-    # Package is not installed, so the package metadata is not available.
-    # This should only happen if a package is importable but the package
-    # metadata is not, as might happen if someone copied files into their
-    # system site-packages or they're importing this package from the CWD.
-    raise RuntimeError(
-        "Could not load version from installed metadata.\n\n"
-        "This is often because the package was not installed properly. "
-        "Ensure that the package is installed in a way that the metadata is "
-        "maintained.  Calls to ``pip`` and this package's ``setup.py`` "
-        "maintain metadata.  Examples include:\n"
-        "  * python setup.py install\n"
-        "  * python setup.py develop\n"
-        "  * pip install <distribution>")

--- a/taskgraph/__init__.py
+++ b/taskgraph/__init__.py
@@ -1,6 +1,5 @@
-"""taskgraph module."""
-from .Task import (
-    TaskGraph, Task, EncapsulatedTaskOp, _TASKGRAPH_DATABASE_FILENAME)
+"""TaskGraph init module."""
+from .Task import TaskGraph
+from .Task import Task
 
-__all__ = [
-    'TaskGraph', 'Task', 'EncapsulatedTaskOp', '_TASKGRAPH_DATABASE_FILENAME']
+__all__ = ['TaskGraph', 'Task']

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -18,6 +18,7 @@ import taskgraph
 LOGGER = logging.getLogger(__name__)
 
 N_TEARDOWN_RETRIES = 5
+MAX_TRY_WAIT_MS = 500
 
 
 def _noop_function(**kwargs):
@@ -140,7 +141,7 @@ class TaskGraphTests(unittest.TestCase):
 
     @retrying.retry(
         stop_max_attempt_number=N_TEARDOWN_RETRIES,
-        wait_exponential_multiplier=250, wait_exponential_max=3000)
+        wait_exponential_multiplier=250, wait_exponential_max=MAX_TRY_WAIT_MS)
     def tearDown(self):
         """Remove temporary directory."""
         try:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -597,56 +597,6 @@ class TaskGraphTests(unittest.TestCase):
         result = list(_get_file_stats(nofile, 'sizetimestamp', [], False))
         self.assertEqual(result, [])
 
-    def test_encapsulatedtaskop(self):
-        """TaskGraph: Test abstract closure task class."""
-        from taskgraph.Task import EncapsulatedTaskOp
-
-        class TestAbstract(EncapsulatedTaskOp):
-            def __init__(self):
-                pass
-
-        # __call__ is abstract so TypeError since it's not implemented
-        with self.assertRaises(TypeError):
-            _ = TestAbstract()
-
-        class TestA(EncapsulatedTaskOp):
-            def __call__(self, x):
-                return x
-
-        class TestB(EncapsulatedTaskOp):
-            def __call__(self, x):
-                return x
-
-        # TestA and TestB should be different because of different class names
-        a = TestA()
-        b = TestB()
-        # results of calls should be the same
-        self.assertEqual(a.__call__(5), b.__call__(5))
-        self.assertNotEqual(a.__name__, b.__name__)
-
-        # two instances with same args should be the same
-        self.assertEqual(TestA().__name__, TestA().__name__)
-
-        # redefine TestA so we get a different hashed __name__
-        class TestA(EncapsulatedTaskOp):
-            def __call__(self, x):
-                return x*x
-
-        new_a = TestA()
-        self.assertNotEqual(a.__name__, new_a.__name__)
-
-        # change internal class constructor to get different hashes
-        class TestA(EncapsulatedTaskOp):
-            def __init__(self, q):
-                super(TestA, self).__init__(q)
-                self.q = q
-
-            def __call__(self, x):
-                return x*x
-
-        init_new_a = TestA(1)
-        self.assertNotEqual(new_a.__name__, init_new_a.__name__)
-
     def test_repeat_targetless_runs(self):
         """TaskGraph: ensure that repeated runs with no targets reexecute."""
         task_graph = taskgraph.TaskGraph(self.workspace_dir, -1)


### PR DESCRIPTION
This PR:

removes the abstract helper class that was supposed to aid in iterative development when the code base of a module/class/function was unreadable. In practice that turned out to be a bad design. closes #12 
adds a function that isolates accesses to the sqlite3 database used by TaskGraph. This makes the code base cleaner and also makes it possible for multiple TaskGraph objects to exist in parallel and use the same database. Note it does not guard against identical operations being executed in parallel, but anything else is fine. closes #11 
All the locks guarding access to the TaskGraph object global state have been removed. These only existed because I thought I needed to guard against reading while writing to global state. The GIL makes all those actions atomic and hence unnecessary. That's why this PR has so many line changes in Task. A lot of them are indenting one to the left. closes #10 