### PR TITLE
Add `get` functionality to TaskGraph

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,14 @@ Unreleased Changes
   successfuly executed it with the same parameters.
 * Removed the ``n_retries`` parameter from ``add_task``. Users are recommended
   to handle retries within functions themselves.
+* Added a ``hash_target_files`` flag to ``add_task`` that when set to False,
+  causes TaskGraph to only note the existance of target files after execution
+  or as part of an evaluation to determine if the Task was precalculated.
+  This is useful for operations that initalize a file but subsequent runs of
+  the program modify it such as a new database or a downloaded file.
+* Fixed an issue on the monitor execution thread that caused shutdown of a
+  TaskGraph object to be delayed up to the amount of delay in the monitor
+  reporting update.
 
 0.8.5 (2019-09-11)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,14 +14,6 @@ Unreleased Changes
 * Removing unnecessary internal locks which will improve runtime performance of
   processing many small Tasks.
 * Refactor to support separate TaskGraph objects that use the same database.
-* ``Task``s can now return the result of the ``func`` call after it is
-  executed. This value is cached in the TaskGraph database for future avoided
-  re-execution and can be retrieved with a call to ``get`` on the Task object
-  once the call is complete. As part of this change the previous behavior of
-  transient runs if a target path list was empty has now been made explicit.
-  There is a new parameter ``transient_run`` that if set True will cause a
-  Task to reexecute on a future TaskGraph object even if a previous generation
-  successfully executed it with the same parameters.
 * Removed the ``n_retries`` parameter from ``add_task``. Users are recommended
   to handle retries within functions themselves.
 * Added a ``hash_target_files`` flag to ``add_task`` that when set to False,
@@ -39,8 +31,8 @@ Unreleased Changes
   path list. In previous versions the Task would execute once per TaskGraph
   instance, now successive ``Task`` objects with the same execution signature
   will use cached results.
-* To support the addition of the ``.get()`` function a flag called
-  ``transient_run`` is added to ``add_task`` that causes TaskGraph to avoid
+* To support the addition of the ``.get()`` function a ``transient_run``
+  parameter is added to ``add_task`` that causes TaskGraph to avoid
   recording a completed ``Task`` even if the execution hash would have been
   identical to a previously completed run where the target artifacts still
   existed.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,14 @@ Unreleased Changes
 * Removing unnecessary internal locks which will improve runtime performance of
   processing many small Tasks.
 * Refactor to support separate TaskGraph objects that use the same database.
+* ``Task``s can now return the result of the ``func`` call after it is
+  executed. This value is cached in the TaskGraph database for future avoided
+  re-execution and can be retrieved with a call to ``get`` on the Task object
+  once the call is complete. As part of this change the previous behavior of
+  transient runs if a target path list was empty has now been made explicit.
+  There is a new parameter ``transient_run`` that if set True will cause a
+  Task to reexecute on a future TaskGraph object even if a previous generation
+  successfuly executed it with the same parameters.
 
 0.8.5 (2019-09-11)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ TaskGraph Release History
 
 Unreleased Changes
 ------------------
-* Updating primary repo url to Github.
+* Updating primary repository URL to GitHub.
 * Adding support for Python 3.8.
 * Removing the ``EncapsulatedOp`` abstract class. In practice the development
   loop that encouraged the use of ``EncapsulatedOp`` is flawed and can lead to
@@ -21,17 +21,29 @@ Unreleased Changes
   transient runs if a target path list was empty has now been made explicit.
   There is a new parameter ``transient_run`` that if set True will cause a
   Task to reexecute on a future TaskGraph object even if a previous generation
-  successfuly executed it with the same parameters.
+  successfully executed it with the same parameters.
 * Removed the ``n_retries`` parameter from ``add_task``. Users are recommended
   to handle retries within functions themselves.
 * Added a ``hash_target_files`` flag to ``add_task`` that when set to False,
-  causes TaskGraph to only note the existance of target files after execution
+  causes TaskGraph to only note the existence of target files after execution
   or as part of an evaluation to determine if the Task was precalculated.
-  This is useful for operations that initalize a file but subsequent runs of
+  This is useful for operations that initialize a file but subsequent runs of
   the program modify it such as a new database or a downloaded file.
 * Fixed an issue on the monitor execution thread that caused shutdown of a
   TaskGraph object to be delayed up to the amount of delay in the monitor
   reporting update.
+* Added a ``.get()`` function for ``Task`` objects that returns the result of
+  the respective ``func`` call. This value is cached in the TaskGraph database
+  and hence can be used to avoid repeated execution. Note the addition of this
+  function changes the functionality of calling ``add_task`` with no target
+  path list. In previous versions the Task would execute once per TaskGraph
+  instance, now successive ``Task`` objects with the same execution signature
+  will use cached results.
+* To support the addition of the ``.get()`` function a flag called
+  ``transient_run`` is added to ``add_task`` that causes TaskGraph to avoid
+  recording a completed ``Task`` even if the execution hash would have been
+  identical to a previously completed run where the target artifacts still
+  existed.
 
 0.8.5 (2019-09-11)
 ------------------

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -635,8 +635,6 @@ class TaskGraph(object):
                 break
             logger = logging.getLogger(record.name)
             logger.handle(record)
-        with open('done.txt', 'w') as donefile:
-            donefile('.done.')
         LOGGER.debug('_handle_logs_from_processes shutting down')
 
     def _execution_monitor(self, monitor_wait_event):

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1051,9 +1051,13 @@ class Task(object):
             self._result_ready = True
 
         # check that the target paths exist and record stats for later
+        if not self._hash_target_files:
+            target_hash_algorithm = 'exists'
+        else:
+            target_hash_algorithm = self._hash_algorithm
         result_target_path_stats = list(
             _get_file_stats(
-                self._target_path_list, self._hash_algorithm, [], False))
+                self._target_path_list, target_hash_algorithm, [], False))
         result_target_path_set = set(
             [x[0] for x in result_target_path_stats])
         target_path_set = set(self._target_path_list)
@@ -1097,9 +1101,13 @@ class Task(object):
         # an expected result. This will allow a task to change its hash in
         # case a different version of a file was passed in.
         # these are the stats of the files that exist that aren't ignored
+        if not self._hash_target_files:
+            target_hash_algorithm = 'exists'
+        else:
+            target_hash_algorithm = self._hash_algorithm
         file_stat_list = list(_get_file_stats(
             [self._args, self._kwargs],
-            self._hash_algorithm,
+            target_hash_algorithm,
             self._target_path_list+self._ignore_path_list,
             self._ignore_directories))
 

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1443,7 +1443,6 @@ def _execute_sqlite(
                     database_path)))
             connection = sqlite3.connect(ro_uri, uri=True)
         elif mode == 'modify':
-            LOGGER.debug('modify')
             connection = sqlite3.connect(database_path)
         else:
             raise ValueError('Unknown mode: %s' % mode)

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1105,7 +1105,7 @@ class Task(object):
         """Return true if _call need not be invoked.
 
         If the task has been precalculated it will fetch the return result from
-        the previous run if possible.
+        the previous run.
 
         Returns:
             True if the Task's target paths exist in the same state as the

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1024,6 +1024,12 @@ class TaskGraphTests(unittest.TestCase):
 
         task_graph.close()
         task_graph.join()
+        del task_graph
+
+        with open(target_path, 'r') as result_file:
+            result_contents = result_file.read()
+        self.assertEqual('testupdated', result_contents)
+
 
     def test_duplicate_call_modify_timestamp(self):
         """TaskGraph: test that duplicate call modified stamp recompute."""

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1346,7 +1346,6 @@ class TaskGraphTests(unittest.TestCase):
                 func=_return_value_once,
                 transient_run=transient_run,
                 args=(expected_value,))
-            value_task.join()
             value = value_task.get()
             self.assertEqual(value, expected_value)
             task_graph.close()
@@ -1364,7 +1363,6 @@ class TaskGraphTests(unittest.TestCase):
                     func=_return_value_once,
                     transient_run=True,
                     args=(expected_value,))
-                value_task.join()
                 value = value_task.get()
                 self.assertEqual(value, expected_value)
             else:
@@ -1373,7 +1371,6 @@ class TaskGraphTests(unittest.TestCase):
                         func=_return_value_once,
                         transient_run=True,
                         args=(expected_value,))
-                    value_task.join()
                     value = value_task.get()
 
             task_graph.close()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -21,6 +21,11 @@ N_TEARDOWN_RETRIES = 5
 MAX_TRY_WAIT_MS = 500
 
 
+def _return_value(value):
+    """Returns the value passed to it."""
+    return value
+
+
 def _noop_function(**kwargs):
     """Does nothing except allow kwargs to be passed."""
     pass
@@ -1281,6 +1286,19 @@ class TaskGraphTests(unittest.TestCase):
         self.assertNotEqual(
             task_a._task_id_hash, task_b._task_id_hash,
             "task ids should be different since the filenames are different")
+
+    def test_return_value(self):
+        """TaskGraph: test that `.get` behavior works as expected."""
+        task_graph = taskgraph.TaskGraph(self.workspace_dir, -1, 0)
+        expected_value = 'a good value'
+        value_task = task_graph.add_task(
+            func=_return_value,
+            args=(expected_value,))
+        value_task.join()
+        value = value_task.get()
+        self.assertEqual(value, expected_value)
+        task_graph.close()
+        task_graph.join()
 
 
 def Fail(n_tries, result_path):


### PR DESCRIPTION
This PR fixes the following issues:

* Fixes #15 by adding a blocking, but timeoutable, `get` function to Tasks that return the return value of the Task's `func` after execution. 
* Helped #15 by adding `transient_run` flag to `add_task` that causes TaskGraph to avoid recording a completed `Task` so successive instatiations of the TaskGraph object will cause that function to reexecute even if it would have otherwise been precalculated.
* Fixes #17 by replacing a `time.sleep` with a `threading.Event` object that has a timeout on its `wait` method. During shutdown the event can be `set` to trigger an immediate wakeup.
* Fixes #16 by adding a `hash_target_files` flag to `add_task` that when False only checks the existence of the target files, not any other aspect of their status.
* Fixes #10 by removing one other uncessary lock.

Also updated history and relevant tests to cover these changes.