### PR TITLE
Bugfix/taskgraph 26 corrupt table

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,15 @@
 TaskGraph Release History
 =========================
 
+Unreleased changes
+------------------
+* Fixed issue that would cause an infinate loop if a ``TaskGraph`` object were
+  created with a database from an incomptable previous version. Behavior now
+  is to log the issue, delete the old database, and create a new compatable
+  one.
+* Fixed issue that would cause some rare infinate loops if ``TaskGraph`` were
+  to fail due to some kinds of task exceptions.
+
 0.9.0 (2020-03-05)
 ------------------
 * Updating primary repository URL to GitHub.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,11 +6,11 @@ TaskGraph Release History
 
 Unreleased changes
 ------------------
-* Fixed issue that would cause an infinate loop if a ``TaskGraph`` object were
-  created with a database from an incomptable previous version. Behavior now
-  is to log the issue, delete the old database, and create a new compatable
+* Fixed issue that would cause an infinite loop if a ``TaskGraph`` object were
+  created with a database from an incompatible previous version. Behavior now
+  is to log the issue, delete the old database, and create a new compatible
   one.
-* Fixed issue that would cause some rare infinate loops if ``TaskGraph`` were
+* Fixed issue that would cause some rare infinite loops if ``TaskGraph`` were
   to fail due to some kinds of task exceptions.
 * Adding open source BSD-3-Clause license.
 

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1478,7 +1478,9 @@ def _normalize_path(path):
     return os.path.normcase(abs_path)
 
 
-@retrying.retry(wait_exponential_multiplier=1000, wait_exponential_max=5000)
+@retrying.retry(
+    wait_exponential_multiplier=1000, wait_exponential_max=5000,
+    stop_max_attempt_number=5)
 def _execute_sqlite(
         sqlite_command, database_path, argument_list=None,
         mode='read_only', execute='execute', fetch=None):

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -183,6 +183,9 @@ def _create_taskgraph_table_schema(taskgraph_database_path):
                 if not table_info_result:
                     raise ValueError(f'missing table {expected_table_name}')
         except Exception:
+            # catch all "Exception"s because anything that goes wrong while
+            # checking the database should be considered a bad dabase and we
+            # should make a new one.
             LOGGER.exception(
                 f'{taskgraph_database_path} exists, but is incompatable '
                 'somehow. Deleting and making a new one.')

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -86,7 +86,7 @@ def _initialize_logging_to_queue(logging_queue):
     ``multiprocessing.Pool`` to establish logging from a Pool worker to the
     main python process via a multiprocessing Queue.
 
-    Parameters:
+    Args:
         logging_queue (multiprocessing.Queue): The queue to use for passing
             log records back to the main process.
 
@@ -110,7 +110,7 @@ def _initialize_logging_to_queue(logging_queue):
 
 
 def _create_taskgraph_table_schema(taskgraph_database_path):
-    """Create database exists and/or ensures it is compatable and recreate.
+    """Create database exists and/or ensures it is compatible and recreate.
 
     Args:
         taskgraph_database_path (str): path to an existing database or desired
@@ -184,10 +184,10 @@ def _create_taskgraph_table_schema(taskgraph_database_path):
                     raise ValueError(f'missing table {expected_table_name}')
         except Exception:
             # catch all "Exception"s because anything that goes wrong while
-            # checking the database should be considered a bad dabase and we
+            # checking the database should be considered a bad database and we
             # should make a new one.
             LOGGER.exception(
-                f'{taskgraph_database_path} exists, but is incompatable '
+                f'{taskgraph_database_path} exists, but is incompatible '
                 'somehow. Deleting and making a new one.')
             os.remove(taskgraph_database_path)
             table_valid = False
@@ -220,7 +220,7 @@ class TaskGraph(object):
         Creates an object for building task graphs, executing them,
         parallelizing independent work notes, and avoiding repeated calls.
 
-        Parameters:
+        Args:
             taskgraph_cache_dir_path (string): path to a directory that
                 either contains a taskgraph cache from a previous instance or
                 will create a new one if none exists.
@@ -537,7 +537,7 @@ class TaskGraph(object):
             transient_run=False):
         """Add a task to the task graph.
 
-        Parameters:
+        Args:
             func (callable): target function
             args (list): argument list for `func`
             kwargs (dict): keyword arguments for `func`
@@ -745,7 +745,7 @@ class TaskGraph(object):
     def _execution_monitor(self, monitor_wait_event):
         """Log state of taskgraph every `self._reporting_interval` seconds.
 
-        Parameters:
+        Args:
             monitor_wait_event (threading.Event): used to sleep the monitor
                 for `self._reporting_interval` seconds, or to wake up to
                 terminate for shutdown.
@@ -789,7 +789,7 @@ class TaskGraph(object):
     def join(self, timeout=None):
         """Join all threads in the graph.
 
-        Parameters:
+        Args:
             timeout (float): if not none will attempt to join subtasks with
                 this value. If a subtask times out, the whole function will
                 timeout.
@@ -885,7 +885,7 @@ class Task(object):
             task_database_path):
         """Make a Task.
 
-        Parameters:
+        Args:
             task_name (int): unique task id from the task graph.
             func (function): a function that takes the argument list
                 `args`
@@ -1345,7 +1345,7 @@ class Task(object):
         determined by a call to `.join()`. Otherwise will wait up to `timeout`
         seconds before raising a `RuntimeError` if exceeded.
 
-        Parameters:
+        Args:
             timeout (float): if not None this parameter is a floating point
                 number specifying a timeout for the operation in seconds.
 
@@ -1366,7 +1366,7 @@ def _get_file_stats(
         ignore_directories):
     """Return fingerprints of any filepaths in `base_value`.
 
-    Parameters:
+    Args:
         base_value: any python value. Any file paths in `base_value`
             should be "os.path.norm"ed before this function is called.
             contains filepaths in any nested structure.
@@ -1432,7 +1432,7 @@ def _filter_non_files(
         base_value, keep_list, ignore_list, keep_directories):
     """Remove any values that are files not in ignore list or directories.
 
-    Parameters:
+    Args:
         base_value: any python value. Any file paths in `base_value`
             should be "os.path.norm"ed before this function is called.
             contains filepaths in any nested structure.
@@ -1488,7 +1488,7 @@ def _scrub_task_args(base_value, target_path_list):
     This function can be called before the Task dependencies are satisfied
     since it doesn't inspect any file stats on disk.
 
-    Parameters:
+    Args:
         base_value: any python value
         target_path_list (list): a list of strings that if found in
             `base_value` should be replaced with 'in_target_path' so
@@ -1538,7 +1538,7 @@ def _scrub_task_args(base_value, target_path_list):
 def _hash_file(file_path, hash_algorithm, buf_size=2**20):
     """Return a hex digest of `file_path`.
 
-    Parameters:
+    Args:
         file_path (string): path to file to hash.
         hash_algorithm (string): a hash function id that exists in
             hashlib.algorithms_available or 'sizetimestamp'. If function id
@@ -1591,7 +1591,7 @@ def _execute_sqlite(
         mode='read_only', execute='execute', fetch=None):
     """Execute SQLite command and attempt retries on a failure.
 
-    Parameters:
+    Args:
         sqlite_command (str): a well formatted SQLite command.
         database_path (str): path to the SQLite database to operate on.
         argument_list (list): `execute == 'execute` then this list is passed to

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1620,8 +1620,9 @@ def _execute_sqlite(
 
         if execute == 'execute':
             if argument_list is None:
-                argument_list = []
-            cursor = connection.execute(sqlite_command, argument_list)
+                cursor = connection.execute(sqlite_command)
+            else:
+                cursor = connection.execute(sqlite_command, argument_list)
         elif execute == 'script':
             cursor = connection.executescript(sqlite_command)
         else:

--- a/taskgraph/__init__.py
+++ b/taskgraph/__init__.py
@@ -1,9 +1,8 @@
 """TaskGraph init module."""
-from pkg_resources import get_distribution
 
 from .Task import TaskGraph
 from .Task import Task
 from .Task import _TASKGRAPH_DATABASE_FILENAME
+from .Task import __version__
 
-__all__ = ['TaskGraph', 'Task', '_TASKGRAPH_DATABASE_FILENAME']
-__version__ = get_distribution(__name__).version
+__all__ = ['__version__', 'TaskGraph', 'Task', '_TASKGRAPH_DATABASE_FILENAME']


### PR DESCRIPTION
This fixes an issue with TaskGraph infinitely looping when loaded with an incompatible task database from a previous version. It also adds a feature that versions the database based on the version of TaskGraph that originally creates the job table. Even if the table appears to be compatible it still logs a warning. This is to in anticipation of some unseen future issue where a table was "valid" but something else related to an old version of a table would cause an issue.  Added tests to cover this new functionality and updated the history.