### PR TITLE
Bugfix/taskgraph 29 terminate when done

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@
 TaskGraph Release History
 =========================
 
+Unrleased Changes
+-----------------
+* Fixed several race conditions that could cause the ``TaskGraph`` object to
+  hang on an otherwise ordinary termination.
+
 0.9.1 (2020-06-04)
 ------------------
 * Fixed issue that would cause an infinite loop if a ``TaskGraph`` object were

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -344,6 +344,7 @@ class TaskGraph(object):
             self._execution_monitor_thread.start()
 
         # launch executor threads
+        self._executor_thread_count = max(0, n_workers)
         for thread_id in range(max(1, n_workers)):
             task_executor_thread = threading.Thread(
                 target=self._task_executor,

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -387,8 +387,10 @@ class TaskGraph(object):
             self._terminated = True
             if self._n_workers > 0:
                 LOGGER.debug("shutting down workers")
-                self._worker_pool.close()
-                self._worker_pool.terminate()
+                if self._worker_pool:
+                    self._worker_pool.close()
+                    self._worker_pool.terminate()
+                    self._worker_pool = None
                 # close down the log monitor thread
                 self._logging_queue.put(None)
                 timedout = not self._logging_monitor_thread.join(_MAX_TIMEOUT)

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -479,7 +479,14 @@ class TaskGraph(object):
                     # the task graph is signaling executors to stop,
                     # since the self._task_dependent_map is empty the
                     # executor can terminate.
-                    self._worker_pool.close()
+                    if self._executor_thread_count == 1 and self._worker_pool:
+                        # only the last executor should terminate the worker
+                        # pool, because otherwise who knows if it's still
+                        # executing anything
+                        self._worker_pool.close()
+                        self._worker_pool.terminate()
+                        self._worker_pool = None
+                    self._executor_thread_count -= 1
                     LOGGER.debug(
                         "no tasks are pending and taskgraph closed, normally "
                         "terminating executor %s." % threading.currentThread())

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -409,7 +409,7 @@ class TaskGraph(object):
                         x = self._logging_queue.get_nowait()
                         LOGGER.debug(
                             "the logging queue had this in it: %s", x)
-                    except queue.Empty:
+                    except Exception:
                         break
 
             self._taskgraph_started_event.set()

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -491,7 +491,7 @@ class TaskGraph(object):
                             self._worker_pool = None
                         except Exception:
                             # there's the possibility for a race condition here
-                            # where anothe thread already closed the worker
+                            # where another thread already closed the worker
                             # pool, so just guard against it
                             LOGGER.warn('worker pool was already closed')
                     LOGGER.debug(
@@ -544,7 +544,7 @@ class TaskGraph(object):
                     self._executor_ready_event.set()
             del self._task_dependent_map[task.task_name]
             # this extra set ensures that recently emptied map won't get
-            # ignored by the exeuctor if no work is left to do and the graph is
+            # ignored by the executor if no work is left to do and the graph is
             # closed
             self._executor_ready_event.set()
             LOGGER.debug("task %s done processing", task.task_name)

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -479,6 +479,7 @@ class TaskGraph(object):
                     # the task graph is signaling executors to stop,
                     # since the self._task_dependent_map is empty the
                     # executor can terminate.
+                    self._worker_pool.close()
                     LOGGER.debug(
                         "no tasks are pending and taskgraph closed, normally "
                         "terminating executor %s." % threading.currentThread())

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -384,7 +384,7 @@ class TaskGraph(object):
             # case we'll wrap it all up in a try/except
             self._terminated = True
             if self._executor_ready_event:
-                # alert exeuctors to check that _terminated is True
+                # alert executors to check that _terminated is True
                 self._executor_ready_event.set()
             LOGGER.debug("shutting down workers")
             if self._worker_pool:

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -403,11 +403,13 @@ class TaskGraph(object):
                         LOGGER.debug(
                             "the logging queue had this in it: %s", x)
                     except Exception:
-                        # Normally this could be an empty Queue, but if the
-                        # TaskGraph were being terminated it's possible this
-                        # object is corrupt and we'd get a different kind
-                        # of exception like EOF. In any case we should always
-                        # terminate in the case of an Exception.
+                        LOGGER.exception(
+                            "Expected an empty logging queue, but if the "
+                            "TaskGraph were being terminated it's possible "
+                            "this object is corrupt and we'd get a different "
+                            "kind of exception like EOF. In any case we "
+                            "should always stop trying to drain the queue "
+                            "in the case of an Exception.")
                         break
 
             if self._n_workers >= 0:

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -403,6 +403,11 @@ class TaskGraph(object):
                         LOGGER.debug(
                             "the logging queue had this in it: %s", x)
                     except Exception:
+                        # Normally this could be an empty Queue, but if the
+                        # TaskGraph were being terminated it's possible this
+                        # object is corrupt and we'd get a different kind
+                        # of exception like EOF. In any case we should always
+                        # terminate in the case of an Exception.
                         break
 
             if self._n_workers >= 0:
@@ -1637,7 +1642,6 @@ def _execute_sqlite(
         return result
     except Exception:
         LOGGER.exception('Exception on _execute_sqlite: %s', sqlite_command)
-        LOGGER.error(f"database_path exists: {os.path.exists(database_path)}")
         if cursor is not None:
             cursor.close()
         if connection is not None:


### PR DESCRIPTION
This fixes complicated-but-possible-to-reproduce hang and several possible race conditions in TaskGraph. This behavior would occur when running a particular Docker container using TaskGraph and was caused by the process pool not being `close`d then `terminate`d. In the process of patching that I simplified a couple duplicate code areas, fixed a couple of possible race conditions, and simplified how executors determine if the should terminate.

In the process of this I removed the `_taskgraph_started_event` object which we'd had around in the past to allow TaskGraph to not start executing until the first `join` was called. In practice this can oeverall slow down execution in cases where a very large graph is to be constructed and as far as I can tell, there are no advantages to that behavior.

