### PR TITLE
fixes #32 implement hard linking to artifacts if desired

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Unrleased Changes
 -----------------
 * Fixed several race conditions that could cause the ``TaskGraph`` object to
   hang on an otherwise ordinary termination.
+* Adding a ``hardlink_allowed`` parameter to ``add_task`` that allows the
+  attempt to hardlink a file in a case where a ``copy_artifact=True`` may
+  permit one. This will save on disk space as well as computation time
+  if large files are not needed to copy.
 
 0.9.1 (2020-06-04)
 ------------------

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -981,7 +981,7 @@ class Task(object):
         self._task_database_path = task_database_path
         self._hash_algorithm = hash_algorithm
         self._copy_duplicate_artifact = copy_duplicate_artifact
-        self.hardlink_allowed = hardlink_allowed
+        self._hardlink_allowed = hardlink_allowed
         self.exception_object = None
 
         # invert the priority since sorting goes smallest to largest and we
@@ -1151,7 +1151,7 @@ class Task(object):
                                     self._target_path_list):
                                 if artifact_target != new_target:
                                     target_linked = False
-                                    if self.hardlink_allowed:
+                                    if self._hardlink_allowed:
                                         # some OSes may not allow hardlinks
                                         # but we don't know unless we try
                                         try:


### PR DESCRIPTION
Adds functionality to allow hardlinking a file in the case when an artifact can otherwise be copied. This PR adds this functionality through an optional ``hardlink_allowed`` parameter that defaults to False. Not all OSes may handle hardlinks, so this is guarded and uses a traditional file copy in case of failure... hence the "allowed" vernacular on the parameter name.