### PR TITLE
fixes #23 change default behavior to not store the result unless specified

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,11 @@ Unrleased Changes
 -----------------
 * Fixed several race conditions that could cause the ``TaskGraph`` object to
   hang on an otherwise ordinary termination.
+* Adding a ``store_result`` flag to ``add_task`` that conditionally stores
+  the ``func`` result in the database for later ``.get``. This was added to
+  guard against return types that were not picklable and would otherwise
+  cause an exception when being executed normally.
+
 
 0.9.1 (2020-06-04)
 ------------------

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -52,29 +52,35 @@ class NoDaemonProcess(multiprocessing.Process):
     """Make 'daemon' attribute always return False."""
     @property
     def daemon(self):
+        """Return False indicating not a daemon process."""
         return False
 
     @daemon.setter
     def daemon(self, value):
+        """Do not allow daemon value to be overriden."""
         pass
 
 
-# From https://stackoverflow.com/a/8963618/42897
-# "As the current implementation of multiprocessing [3.7+] has been extensively
-# refactored to be based on contexts, we need to provide a NoDaemonContext
-# class that has our NoDaemonProcess as attribute. [NonDaemonicPool] will then
-# use that context instead of the default one."
-# "spawn" is chosen as default since that is the default and only context
-# option for Windows and is the default option for Mac OS as well since 3.8.
 class NoDaemonContext(type(multiprocessing.get_context('spawn'))):
+    """From https://stackoverflow.com/a/8963618/42897.
+
+    "As the current implementation of multiprocessing [3.7+] has been
+    extensively refactored to be based on contexts, we need to provide a
+    NoDaemonContext class that has our NoDaemonProcess as attribute.
+    [NonDaemonicPool] will then use that context instead of the default
+    one." "spawn" is chosen as default since that is the default and only
+    context option for Windows and is the default option for Mac OS as
+    well since 3.8.
+
+    """
     Process = NoDaemonProcess
 
 
 class NonDaemonicPool(multiprocessing.pool.Pool):
     """NonDaemonic Process Pool."""
 
-    # Invoking super to set the context of Pool class explicitly
     def __init__(self, *args, **kwargs):
+        """Invoking super to set the context of Pool class explicitly."""
         kwargs['context'] = NoDaemonContext()
         super(NonDaemonicPool, self).__init__(*args, **kwargs)
 
@@ -96,16 +102,16 @@ def _initialize_logging_to_queue(logging_queue):
             log records back to the main process.
 
     Returns:
-        ``None``
+        None
 
     """
     root_logger = logging.getLogger()
 
-    # By the time this function is called, ``root_logger`` has a copy of all of
+    # By the time this function is called, `root_logger` has a copy of all of
     # the logging handlers registered to it within the parent process, which
     # leads to duplicate logging in some cases.  By removing all of the
     # handlers here, we ensure that log messages can only be passed back to the
-    # parent process by the ``logging_queue``, where they will be handled.
+    # parent process by the `logging_queue`, where they will be handled.
     for handler in root_logger.handlers[:]:
         root_logger.removeHandler(handler)
 
@@ -233,9 +239,9 @@ class TaskGraph(object):
                 during task graph execution.  If set to 0, don't use
                 subprocesses.  If set to <0, use only the main thread for any
                 execution and scheduling. In the case of the latter,
-                `add_task` will be a blocking call.
+                ``add_task`` will be a blocking call.
             reporting_interval (scalar): if not None, report status of task
-                graph every `reporting_interval` seconds.
+                graph every ``reporting_interval`` seconds.
 
         """
         try:
@@ -566,20 +572,21 @@ class TaskGraph(object):
 
         Args:
             func (callable): target function
-            args (list): argument list for `func`
-            kwargs (dict): keyword arguments for `func`
+            args (list): argument list for ``func``
+            kwargs (dict): keyword arguments for ``func``
             target_path_list (list): if not None, a list of file paths that
-                are expected to be output by `func`.  If any of these paths
+                are expected to be output by ``func``.  If any of these paths
                 don't exist, or their timestamp is earlier than an input
                 arg or work token, func will be executed.
 
-                If `None`, any identical calls to `add_task` will be skipped
-                for the TaskGraph object. A future TaskGraph object will
-                re-run an exact call once for its lifetime. The reasoning is
-                that it is likely the user wishes to run a target-less task
-                once for the lifetime of a task-graph, but would otherwise
-                not have a transient result that could be re-used in a
-                future instantiation of a TaskGraph object.
+                If ``None``, any identical calls to ``add_task`` will be
+                skipped for the TaskGraph object. A future TaskGraph object
+                will re-run an exact call once for its lifetime. The reasoning
+                is that it is likely the user wishes to run a target-less task
+                once for the lifetime of a task-graph, but would otherwise not
+                have a transient result that could be re-used in a future
+                instantiation of a TaskGraph object.
+
             task_name (string): if not None, this value is used to identify
                 the task in logging messages.
             ignore_path_list (list): list of file paths that could be in
@@ -590,8 +597,8 @@ class TaskGraph(object):
                 function is precalculated. If False, this function only notes
                 the existence of the target files before determining if
                 a function call is precalculated.
-            dependent_task_list (list): list of `Task`s that this task must
-                `join` before executing.
+            dependent_task_list (list): list of ``Task``s that this task must
+                ``join`` before executing.
             ignore_directories (boolean): if the existence/timestamp of any
                 directories discovered in args or kwargs is used as part
                 of the work token hash.
@@ -609,9 +616,9 @@ class TaskGraph(object):
                 files found in the arguments. This value is used when
                 determining whether a task is precalculated or its target
                 files can be copied to an equivalent task. Note if
-                `hash_algorithm` is 'sizetimestamp' the task will require the
+                ``hash_algorithm`` is 'sizetimestamp' the task will require the
                 same base path files to determine equality. If it is a
-                `hashlib` algorithm only file contents will be considered.
+                ``hashlib`` algorithm only file contents will be considered.
             copy_duplicate_artifact (bool): if True and the Tasks'
                 argument signature matches a previous Tasks without direct
                 comparison of the target path files in the arguments other
@@ -636,9 +643,9 @@ class TaskGraph(object):
         Raises:
             ValueError if objects are passed to the dependent task list that
                 are not Tasks.
-            ValueError if `add_task` is invoked after the `TaskGraph` is
+            ValueError if ``add_task`` is invoked after the ``TaskGraph`` is
                 closed.
-            RuntimeError if `add_task` is invoked after `TaskGraph` has
+            RuntimeError if ``add_task`` is invoked after ``TaskGraph`` has
                 reached a terminate state.
 
         """
@@ -773,11 +780,11 @@ class TaskGraph(object):
         LOGGER.debug('_handle_logs_from_processes shutting down')
 
     def _execution_monitor(self, monitor_wait_event):
-        """Log state of taskgraph every `self._reporting_interval` seconds.
+        """Log state of taskgraph every ``self._reporting_interval`` seconds.
 
         Args:
             monitor_wait_event (threading.Event): used to sleep the monitor
-                for `self._reporting_interval` seconds, or to wake up to
+                for``self._reporting_interval`` seconds, or to wake up to
                 terminate for shutdown.
 
         Returns:
@@ -906,10 +913,10 @@ class Task(object):
         Args:
             task_name (int): unique task id from the task graph.
             func (function): a function that takes the argument list
-                `args`
-            args (tuple): a list of arguments to pass to `func`.  Can be
+               ``args``
+            args (tuple): a list of arguments to pass to ``func``.  Can be
                 None.
-            kwargs (dict): keyword arguments to pass to `func`.  Can be
+            kwargs (dict): keyword arguments to pass to ``func``.  Can be
                 None.
             target_path_list (list): a list of filepaths that this task
                 should generate.
@@ -931,7 +938,7 @@ class Task(object):
                 Otherwise if False, subsequent tasks with an identical
                 execution hash will be skipped.
             worker_pool (multiprocessing.Pool): if not None, is a
-                multiprocessing pool that can be used for `_call` execution.
+                multiprocessing pool that can be used for ``_call`` execution.
             cache_dir (string): path to a directory to both write and expect
                 data recorded from a previous Taskgraph run.
             priority (numeric): the priority of a task is considered when
@@ -962,8 +969,8 @@ class Task(object):
                 If a call is successful its hash is inserted/updated in the
                 table, the target_path_stats stores the base/target stats
                 for the target files created by the call and listed in
-                `target_path_list`, and the result of `func` is stored in
-                "result".
+                ``target_path_list``, and the result of ``func`` is stored in
+                ``result``.
 
         """
         # it is a common error to accidentally pass a non string as to the
@@ -1073,7 +1080,7 @@ class Task(object):
         self._task_id_hash = hashlib.sha1(
             argument_hash_string.encode('utf-8')).hexdigest()
 
-        # this will get calculated when `is_precalculated` is invoked.
+        # this will get calculated when ``is_precalculated`` is invoked.
         self._task_reexecution_hash = None
 
     def __eq__(self, other):
@@ -1115,7 +1122,7 @@ class Task(object):
 
         Precondition is that the Task dependencies are satisfied.
 
-        Sets the `self.task_done_executing_event` flag if execution is
+        Sets the ``self.task_done_executing_event`` flag if execution is
         successful.
 
         Raises:
@@ -1363,7 +1370,7 @@ class Task(object):
 
         If ``timeout`` is None, this call blocks until the task is complete
         determined by a call to ``.join()``. Otherwise will wait up to
-        ``timeout`` seconds before raising a `RuntimeError` if exceeded.
+        ``timeout`` seconds before raising a``RuntimeError`` if exceeded.
 
         Args:
             timeout (float): if not None this parameter is a floating point
@@ -1391,10 +1398,10 @@ class Task(object):
 def _get_file_stats(
         base_value, hash_algorithm, ignore_list,
         ignore_directories):
-    """Return fingerprints of any filepaths in `base_value`.
+    """Return fingerprints of any filepaths in ``base_value``.
 
     Args:
-        base_value: any python value. Any file paths in `base_value`
+        base_value: any python value. Any file paths in ``base_value``
             should be "os.path.norm"ed before this function is called.
             contains filepaths in any nested structure.
         hash_algorithm (string): either a hash function id that
@@ -1405,10 +1412,10 @@ def _get_file_stats(
             files found in the arguments. This value is used when
             determining whether a task is precalculated or its target
             files can be copied to an equivalent task. Note if
-            `hash_algorithm` is 'sizetimestamp' the task will require the
+            ``hash_algorithm`` is 'sizetimestamp' the task will require the
             same base path files to determine equality. If it is a
-            `hashlib` algorithm only file contents will be considered. If this
-            value is 'exists' the value of the hash will be 'exists'.
+            ``hashlib`` algorithm only file contents will be considered. If
+            this value is 'exists' the value of the hash will be 'exists'.
         ignore_list (list): any paths found in this list are not included
             as part of the file stats. All paths in this list should be
             "os.path.norm"ed.
@@ -1460,7 +1467,7 @@ def _filter_non_files(
     """Remove any values that are files not in ignore list or directories.
 
     Args:
-        base_value: any python value. Any file paths in `base_value`
+        base_value: any python value. Any file paths in ``base_value``
             should be "os.path.norm"ed before this function is called.
             contains filepaths in any nested structure.
         keep_list (list): any paths found in this list are not filtered.
@@ -1470,7 +1477,7 @@ def _filter_non_files(
             out.
 
     Return:
-        original `base_value` with any nested file paths for files that
+        original``base_value`` with any nested file paths for files that
         exist in the os.exists removed.
 
     """
@@ -1505,11 +1512,11 @@ def _filter_non_files(
 
 
 def _scrub_task_args(base_value, target_path_list):
-    """Attempt to convert `base_value` to canonical values.
+    """Attempt to convert ``base_value`` to canonical values.
 
-    Any paths in `base_value` are normalized, any paths that are also in
-    the `target_path_list` are replaced with a placeholder so that if
-    all other arguments are the same in `base_value` except target path
+    Any paths in ``base_value`` are normalized, any paths that are also in
+    the``target_path_list`` are replaced with a placeholder so that if
+    all other arguments are the same in ``base_value`` except target path
     name the function will hash to the same.
 
     This function can be called before the Task dependencies are satisfied
@@ -1518,11 +1525,11 @@ def _scrub_task_args(base_value, target_path_list):
     Args:
         base_value: any python value
         target_path_list (list): a list of strings that if found in
-            `base_value` should be replaced with 'in_target_path' so
+            ``base_value`` should be replaced with 'in_target_path' so
 
     Returns:
         base_value with any functions replaced as strings and paths in
-            `target_path_list` with a 'target_path_list[n]' placeholder.
+            ``target_path_list`` with a 'target_path_list[n]' placeholder.
 
     """
     if callable(base_value):
@@ -1563,7 +1570,7 @@ def _scrub_task_args(base_value, target_path_list):
 
 
 def _hash_file(file_path, hash_algorithm, buf_size=2**20):
-    """Return a hex digest of `file_path`.
+    """Return a hex digest of ``file_path``.
 
     Args:
         file_path (string): path to file to hash.
@@ -1574,12 +1581,12 @@ def _hash_file(file_path, hash_algorithm, buf_size=2**20):
             'sizetimestamp' the size and timestamp of the file are returned
             in a string of the form
             '[sizeinbytes]:[lastmodifiedtime]'.
-        buf_size (int): number of bytes to read from `file_path` at a time
+        buf_size (int): number of bytes to read from ``file_path`` at a time
             for digesting.
 
     Returns:
-        a hash hex digest computed with hash algorithm `hash_algorithm`
-        of the binary contents of the file located at `file_path`.
+        a hash hex digest computed with hash algorithm ``hash_algorithm``
+        of the binary contents of the file located at ``file_path``.
 
     """
     if hash_algorithm == 'sizetimestamp':
@@ -1597,7 +1604,7 @@ def _hash_file(file_path, hash_algorithm, buf_size=2**20):
 
 
 def _normalize_path(path):
-    """Convert `path` into normalized, normcase, absolute filepath."""
+    """Convert ``path`` into normalized, normcase, absolute filepath."""
     norm_path = os.path.normpath(path)
     try:
         abs_path = os.path.abspath(norm_path)
@@ -1621,16 +1628,16 @@ def _execute_sqlite(
     Args:
         sqlite_command (str): a well formatted SQLite command.
         database_path (str): path to the SQLite database to operate on.
-        argument_list (list): `execute == 'execute` then this list is passed to
-            the internal sqlite3 `execute` call.
+        argument_list (list): ``execute == 'execute'`` then this list is passed
+            to the internal sqlite3 ``execute`` call.
         mode (str): must be either 'read_only' or 'modify'.
         execute (str): must be either 'execute' or 'script'.
-        fetch (str): if not `None` can be either 'all' or 'one'.
+        fetch (str): if not ``None`` can be either 'all' or 'one'.
             If not None the result of a fetch will be returned by this
             function.
 
     Returns:
-        result of fetch if `fetch` is not None.
+        result of fetch if ``fetch`` is not None.
 
     """
     cursor = None

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -35,12 +35,12 @@ def _noop_function(**kwargs):
 
 
 def _long_running_function(delay):
-    """Wait for `delay` seconds."""
+    """Wait for ``delay`` seconds."""
     time.sleep(delay)
 
 
 def _create_two_files_on_disk(value, target_a_path, target_b_path):
-    """Create two files and write `value` and append if possible."""
+    """Create two files and write ``value`` and append if possible."""
     with open(target_a_path, 'a') as a_file:
         a_file.write(value)
 
@@ -57,18 +57,18 @@ def _merge_and_append_files(base_a_path, base_b_path, target_path):
 
 
 def _create_list_on_disk(value, length, target_path=None):
-    """Create a numpy array on disk filled with value of `size`."""
+    """Create a numpy array on disk filled with value of ``size``."""
     target_list = [value] * length
     pickle.dump(target_list, open(target_path, 'wb'))
 
 
 def _call_it(target, *args):
-    """Invoke `target` with `args`."""
+    """Invoke ``target`` with ``args``."""
     target(*args)
 
 
 def _append_val(path, *val):
-    """Append a `val` to file at `path`."""
+    """Append a ``val`` to file at ``path``."""
     with open(path, 'a') as target_file:
         for v in val:
             target_file.write(str(v))
@@ -124,7 +124,7 @@ def _copy_two_files_once(base_path, target_a_path, target_b_path):
 def _log_from_another_process(logger_name, log_message):
     """Write a log message to a given logger.
 
-    Parameters:
+    Args:
         logger_name (string): The string logger name to which ``log_message``
             will be logged.
         log_message (string): The string log message to be logged (at INFO
@@ -231,8 +231,8 @@ class TaskGraphTests(unittest.TestCase):
         """TaskGraph: test that relative path equates to absolute."""
         task_graph = taskgraph.TaskGraph(self.workspace_dir, 0)
 
-        target_a_path = os.path.relpath(
-            os.path.join(self.workspace_dir, 'a.txt'), start=self.workspace_dir)
+        target_a_path = os.path.relpath(os.path.join(
+            self.workspace_dir, 'a.txt'), start=self.workspace_dir)
         target_b_path = os.path.abspath(target_a_path)
 
         _ = task_graph.add_task(
@@ -845,7 +845,7 @@ class TaskGraphTests(unittest.TestCase):
 
         # this causes the address to change
         def _append_val(path, *val):
-            """Append a `val` to file at `path`."""
+            """Append a ``val`` to file at ``path``."""
             with open(path, 'a') as target_file:
                 for v in val:
                     target_file.write(str(v))
@@ -1029,7 +1029,6 @@ class TaskGraphTests(unittest.TestCase):
         with open(target_path, 'r') as result_file:
             result_contents = result_file.read()
         self.assertEqual('testupdated', result_contents)
-
 
     def test_duplicate_call_modify_timestamp(self):
         """TaskGraph: test that duplicate call modified stamp recompute."""
@@ -1335,18 +1334,21 @@ class TaskGraphTests(unittest.TestCase):
             "task ids should be different since the filenames are different")
 
     def test_return_value_no_record(self):
-        """TaskGraph: test that `get` raises exception if not set to record."""
+        """TaskGraph: test  ``get`` raises exception if not set to record."""
         task_graph = taskgraph.TaskGraph(self.workspace_dir, -1)
         value_task = task_graph.add_task(
             func=_noop_function,
             store_result=False)
 
         # get wil raise a ValueError because store_result is not True
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             _ = value_task.get()
+        expected_message = 'must set `store_result` to True in `add_task`'
+        actual_message = str(cm.exception)
+        self.assertTrue(expected_message in actual_message, actual_message)
 
     def test_return_value(self):
-        """TaskGraph: test that `.get` behavior works as expected."""
+        """TaskGraph: test that ``.get`` behavior works as expected."""
         n_iterations = 3
         for iteration_id in range(n_iterations):
             transient_run = iteration_id == n_iterations-1
@@ -1473,7 +1475,7 @@ class TaskGraphTests(unittest.TestCase):
 
 
 def Fail(n_tries, result_path):
-    """Create a function that fails after `n_tries`."""
+    """Create a function that fails after ``n_tries``."""
     def fail_func():
         fail_func._n_tries -= 1
         if fail_func._n_tries > 0:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1334,6 +1334,17 @@ class TaskGraphTests(unittest.TestCase):
             task_a._task_id_hash, task_b._task_id_hash,
             "task ids should be different since the filenames are different")
 
+    def test_return_value_no_record(self):
+        """TaskGraph: test that `get` raises exception if not set to record."""
+        task_graph = taskgraph.TaskGraph(self.workspace_dir, -1)
+        value_task = task_graph.add_task(
+            func=_noop_function,
+            store_result=False)
+
+        # get wil raise a ValueError because store_result is not True
+        with self.assertRaises(ValueError):
+            _ = value_task.get()
+
     def test_return_value(self):
         """TaskGraph: test that `.get` behavior works as expected."""
         n_iterations = 3
@@ -1345,6 +1356,7 @@ class TaskGraphTests(unittest.TestCase):
             value_task = task_graph.add_task(
                 func=_return_value_once,
                 transient_run=transient_run,
+                store_result=True,
                 args=(expected_value,))
             value = value_task.get()
             self.assertEqual(value, expected_value)
@@ -1362,6 +1374,7 @@ class TaskGraphTests(unittest.TestCase):
                 value_task = task_graph.add_task(
                     func=_return_value_once,
                     transient_run=True,
+                    store_result=True,
                     args=(expected_value,))
                 value = value_task.get()
                 self.assertEqual(value, expected_value)
@@ -1370,6 +1383,7 @@ class TaskGraphTests(unittest.TestCase):
                     value_task = task_graph.add_task(
                         func=_return_value_once,
                         transient_run=True,
+                        store_result=True,
                         args=(expected_value,))
                     value = value_task.get()
 


### PR DESCRIPTION
Adds a `store_result` flag to ``add_task`` to conditionally store a result rather than do it by default. In turn, `get` will now raise an exception if invoked on a `Task` created where the `store_result` flag is False. This PR adds that functionality, tests to cover it, and an update to history.