### PR TITLE
fixes #31 change default logging level for precalculated to INFO

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Unrleased Changes
 -----------------
 * Fixed several race conditions that could cause the ``TaskGraph`` object to
   hang on an otherwise ordinary termination.
+* Changed logging level to "INFO" on cases where the taskgraph was not
+  precalculated since it's an expected path of execution in ``TaskGraph``.
 
 0.9.1 (2020-06-04)
 ------------------

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1313,7 +1313,7 @@ class Task(object):
                             "File hashes are different. cached: (%s) "
                             "actual: (%s)" % (hash_string, target_hash))
             if mismatched_target_file_list:
-                LOGGER.warning(
+                LOGGER.info(
                     "not precalculated (%s), Task hash exists, "
                     "but there are these mismatches: %s",
                     self.task_name, '\n'.join(mismatched_target_file_list))


### PR DESCRIPTION
Changes the level of the "not precalculated" logging message from a WARNING to INFO. 

Closes #31 