### PR TITLE
Terminate logging thread when TaskGraph is complete

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Unrleased Changes
 -----------------
 * Fixed several race conditions that could cause the ``TaskGraph`` object to
   hang on an otherwise ordinary termination.
+* Fixed issue that would cause the logger thread to continue reporting status
+  after all tasks were complete and the graph was closed.
 
 0.9.1 (2020-06-04)
 ------------------

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -841,8 +841,8 @@ class TaskGraph(object):
                         "task %s timed out in graph join", task.task_name)
                     return False
             if self._closed and self._logging_queue:
-                # Close down the logging monitor thread.
-                self._logging_queue.put(None)
+                # Close down the taskgraph
+                self._terminate()
             return True
         except Exception:
             # If there's an exception on a join it means that a task failed
@@ -874,6 +874,9 @@ class TaskGraph(object):
         if self._terminated:
             return
         self._terminated = True
+
+        if self._logging_queue:
+            self._logging_queue.put(None)
 
         for task in self._task_hash_map.values():
             LOGGER.debug("setting task done for %s", task.task_name)

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -840,7 +840,7 @@ class TaskGraph(object):
                     LOGGER.info(
                         "task %s timed out in graph join", task.task_name)
                     return False
-            if self._logging_queue:
+            if self._closed and self._logging_queue:
                 # Close down the logging monitor thread.
                 self._logging_queue.put(None)
             return True

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -840,6 +840,9 @@ class TaskGraph(object):
                     LOGGER.info(
                         "task %s timed out in graph join", task.task_name)
                     return False
+            if self._logging_queue:
+                # Close down the logging monitor thread.
+                self._logging_queue.put(None)
             return True
         except Exception:
             # If there's an exception on a join it means that a task failed

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -79,6 +79,11 @@ class NonDaemonicPool(multiprocessing.pool.Pool):
         super(NonDaemonicPool, self).__init__(*args, **kwargs)
 
 
+def _null_func():
+    """Used when func=None on add_task."""
+    return None
+
+
 def _initialize_logging_to_queue(logging_queue):
     """Add a synchronized queue to a new process.
 
@@ -656,7 +661,7 @@ class TaskGraph(object):
             if ignore_path_list is None:
                 ignore_path_list = []
             if func is None:
-                def func(): return None
+                func = _null_func
 
             # this is a pretty common error to accidentally not pass a
             # Task to the dependent task list.

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1440,11 +1440,15 @@ class TaskGraphTests(unittest.TestCase):
         task_graph = taskgraph.TaskGraph(self.workspace_dir, 1, 5.0)
         _ = task_graph.add_task()
         task_graph.join()
-        # logger should not terminate until after join
-        task_graph._logging_monitor_thread.join(0.001)
+
+        # logger should not terminate until after join, give it enough time
+        # to have a chance to close, but not so long the test hangs
+        task_graph._logging_monitor_thread.join(0.1)
         self.assertTrue(task_graph._logging_monitor_thread.is_alive())
+
         task_graph.close()
         task_graph.join()
+        # 5 seconds should be way too much time to expect the thread to join
         task_graph._logging_monitor_thread.join(5)
         self.assertFalse(task_graph._logging_monitor_thread.is_alive())
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1435,6 +1435,19 @@ class TaskGraphTests(unittest.TestCase):
                         'taskgraph_data ')
             self.assertEqual(len(result), len(expected_column_name_list))
 
+    def test_terminate_log(self):
+        """TaskGraph: test that the logger thread terminates on .join."""
+        task_graph = taskgraph.TaskGraph(self.workspace_dir, 1, 5.0)
+        _ = task_graph.add_task()
+        task_graph.join()
+        # logger should not terminate until after join
+        task_graph._logging_monitor_thread.join(0.001)
+        self.assertTrue(task_graph._logging_monitor_thread.is_alive())
+        task_graph.close()
+        task_graph.join()
+        task_graph._logging_monitor_thread.join(5)
+        self.assertFalse(task_graph._logging_monitor_thread.is_alive())
+
 
 def Fail(n_tries, result_path):
     """Create a function that fails after `n_tries`."""

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1445,12 +1445,17 @@ class TaskGraphTests(unittest.TestCase):
         # to have a chance to close, but not so long the test hangs
         task_graph._logging_monitor_thread.join(0.1)
         self.assertTrue(task_graph._logging_monitor_thread.is_alive())
+        task_graph._execution_monitor_thread.join(0.1)
+        self.assertTrue(task_graph._execution_monitor_thread.is_alive())
 
         task_graph.close()
         task_graph.join()
+
         # 5 seconds should be way too much time to expect the thread to join
         task_graph._logging_monitor_thread.join(5)
         self.assertFalse(task_graph._logging_monitor_thread.is_alive())
+        task_graph._execution_monitor_thread.join(5)
+        self.assertFalse(task_graph._execution_monitor_thread.is_alive())
 
 
 def Fail(n_tries, result_path):


### PR DESCRIPTION
This PR fixes an issue that would cause the TaskGraph logging thread to continue reporting status updates even after it is closed and joined. Now the logging thread is terminated. This PR includes that fix, and update to history, as well as a test to cover this case.

Closes #37 