### PR TITLE
Bugfix/transient run fail 40

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@
 TaskGraph Release History
 =========================
 
+Unreleased Changes
+------------------
+* Fixed an issue that would ignore the state of a ``transient_run`` flag if
+  a previous Task run had run it with that flag set to False.
+
 0.10.0 (2020-08-25)
 -------------------
 * Fixed several race conditions that could cause the ``TaskGraph`` object to

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1138,7 +1138,7 @@ class Task(object):
 
         """
         LOGGER.debug("_call check if precalculated %s", self.task_name)
-        if self.is_precalculated():
+        if not self.transient_run and self.is_precalculated():
             self.task_done_executing_event.set()
             return
         LOGGER.debug("not precalculated %s", self.task_name)

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -627,14 +627,16 @@ class TaskGraph(object):
                 be copied to the new one.
             hardlink_allowed (bool): if ``copy_duplicate_artifact`` is True,
                 this will allow a hardlink rather than a copy when needed.
-            transient_run (bool): if True a call with an identical execution
-                hash will be reexecuted on the same or subsequent instantiation
-                of a TaskGraph object. If a duplicate task is submitted
-                to the same object it will not be re-run in any scenario.
-                If False, subsequent tasks with an identical execution hash
-                will be skipped.
+            transient_run (bool): if True, this Task will be reexecuted
+                even if it was successfully executed in a previous TaskGraph
+                instance. If False, this Task will be skipped if it was
+                executed successfully in a previous TaskGraph instance. One
+                might wish to set `transient_run` to True on a Task that does
+                some sort of initialization that's needed every time a
+                TaskGraph is instantiated. Perhaps to acquire dynamic resources
+                or authenticate permissions.
             store_result (bool): If True, the result of ``func`` will be stored
-                in the TaskGraph database and retrieveable with a call to
+                in the TaskGraph database and retrievable with a call to
                 ``.get()`` on a ``Task`` object.
 
         Returns:

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1138,7 +1138,7 @@ class Task(object):
 
         """
         LOGGER.debug("_call check if precalculated %s", self.task_name)
-        if not self.transient_run and self.is_precalculated():
+        if not self._transient_run and self.is_precalculated():
             self.task_done_executing_event.set()
             return
         LOGGER.debug("not precalculated %s", self.task_name)

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -628,11 +628,11 @@ class TaskGraph(object):
             hardlink_allowed (bool): if ``copy_duplicate_artifact`` is True,
                 this will allow a hardlink rather than a copy when needed.
             transient_run (bool): if True a call with an identical execution
-                hash will be reexecuted on a subsequent instantiation of a
-                future TaskGraph object. If a duplicate task is submitted
+                hash will be reexecuted on the same or subsequent instantiation
+                of a TaskGraph object. If a duplicate task is submitted
                 to the same object it will not be re-run in any scenario.
-                Otherwise if False, subsequent tasks with an identical
-                execution hash will be skipped.
+                If False, subsequent tasks with an identical execution hash
+                will be skipped.
             store_result (bool): If True, the result of ``func`` will be stored
                 in the TaskGraph database and retrieveable with a call to
                 ``.get()`` on a ``Task`` object.

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1368,6 +1368,25 @@ class TaskGraphTests(unittest.TestCase):
         if hasattr(_return_value_once, 'executed'):
             del _return_value_once.executed
         n_iterations = 3
+        task_graph = taskgraph.TaskGraph(self.workspace_dir, 0, 0)
+        for iteration_id in range(n_iterations):
+            transient_run = iteration_id == n_iterations-1
+            LOGGER.debug(iteration_id)
+            expected_value = 'a good value'
+            value_task = task_graph.add_task(
+                func=_return_value_once,
+                transient_run=transient_run,
+                store_result=True,
+                args=(expected_value,),
+                task_name=f'{expected_value} iter {iteration_id}')
+            value = value_task.get()
+            self.assertEqual(value, expected_value)
+        task_graph.close()
+        task_graph.join()
+        task_graph = None
+
+        # reset run
+        del _return_value_once.executed
         for iteration_id in range(n_iterations):
             LOGGER.debug(iteration_id)
             task_graph = taskgraph.TaskGraph(self.workspace_dir, 0, 0)
@@ -1375,7 +1394,7 @@ class TaskGraphTests(unittest.TestCase):
             if iteration_id == 0:
                 value_task = task_graph.add_task(
                     func=_return_value_once,
-                    transient_run=False,
+                    transient_run=True,
                     store_result=True,
                     args=(expected_value,),
                     task_name=f'first re-run transient')
@@ -1388,7 +1407,7 @@ class TaskGraphTests(unittest.TestCase):
                         transient_run=True,
                         store_result=True,
                         args=(expected_value,),
-                        task_name=f'expected error on {iteration_id}')
+                        task_name=f'expected error {iteration_id}')
                     value = value_task.get()
 
             task_graph.close()


### PR DESCRIPTION
Fixes unexpected behavior when the `transient_run=True` flag is used if a task had been previously run without that flag then the task would not reexecute even though the user would expect it to.

This PR adds a check for this state, modifies a test to cover this behavior and cleans up some of the wording in the docstring about this flag.