### PR TITLE
Fixes #44, bumping up max attempt number and logging relevaant info

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Unreleased Changes
 ------------------
 * Fixed an issue that would ignore the state of a ``transient_run`` flag if
   a previous Task run had run it with that flag set to False.
+* Removed a limit on the number of times ``TaskGraph`` can attempt to update
+  its database up to 5 minutes of continuous failures. This is to address
+  expected issues when many parallel threads may compete for an update.
+  Relevant information about why the database update fails is logged.
 
 0.10.0 (2020-08-25)
 -------------------

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1643,8 +1643,8 @@ def _normalize_path(path):
 
 
 @retrying.retry(
-    wait_exponential_multiplier=100, wait_exponential_max=3200,
-    stop_max_attempt_number=5)
+    wait_exponential_multiplier=500, wait_exponential_max=3200,
+    stop_max_attempt_number=100)
 def _execute_sqlite(
         sqlite_command, database_path, argument_list=None,
         mode='read_only', execute='execute', fetch=None):
@@ -1704,6 +1704,10 @@ def _execute_sqlite(
         connection.commit()
         connection.close()
         return result
+    except sqlite3.OperationalError:
+        LOGGER.warning(
+            'TaskGraph database is locked because another process is using '
+            'it, waiting for a bit of time to try again')
     except Exception:
         LOGGER.exception('Exception on _execute_sqlite: %s', sqlite_command)
         if cursor is not None:

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1708,11 +1708,13 @@ def _execute_sqlite(
         LOGGER.warning(
             'TaskGraph database is locked because another process is using '
             'it, waiting for a bit of time to try again')
+        raise
     except Exception:
         LOGGER.exception('Exception on _execute_sqlite: %s', sqlite_command)
+        raise
+    finally:
         if cursor is not None:
             cursor.close()
         if connection is not None:
             connection.commit()
             connection.close()
-        raise

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1703,6 +1703,8 @@ def _execute_sqlite(
         cursor.close()
         connection.commit()
         connection.close()
+        cursor = None
+        connection = None
         return result
     except sqlite3.OperationalError:
         LOGGER.warning(


### PR DESCRIPTION
This PR "fixes" a case where many competing threads could lock the TaskGraph SQLite database in a way that is expected and reasonable behavior on the part of the client. What was unexpected is that TaskGraph quit after 5 attempts per thread. I've increased that to 100 which is the equivalent of about 5 minutes of retrying and logged a better logging message for the specific database lock issue.