### PR TITLE
fixes #46, check for empty and updated history

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ Unreleased Changes
   its database up to 5 minutes of continuous failures. This is to address
   expected issues when many parallel threads may compete for an update.
   Relevant information about why the database update fails is logged.
+* Fixed an issue where the logging queue would always report an exception
+  even if the logging thread shut down correctly.
 
 0.10.0 (2020-08-25)
 -------------------

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -413,6 +413,8 @@ class TaskGraph(object):
                         x = self._logging_queue.get_nowait()
                         LOGGER.debug(
                             "the logging queue had this in it: %s", x)
+                    except queue.Empty:
+                        break
                     except Exception:
                         LOGGER.exception(
                             "Expected an empty logging queue, but if the "


### PR DESCRIPTION
Fixes an issue that incorrectly reported an error in the logging queue thread even if it had shut down successfully. 