### PR TITLE
fixes #53 combinatorial memory usage in `dict` arg

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,12 @@
 TaskGraph Release History
 =========================
 
+Unreleased Changes
+------------------
+* Fixed issue that could cause combinatorial memory usage leading to poor
+  runtime or ``MemoryError`` if a dictionary were passed that had thousands
+  of elements.
+
 0.10.2 (2020-12-11)
 -------------------
 * Fixed an issue that would raise an exception when `__del__` was

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ Unreleased Changes
 * Fixed issue that could cause combinatorial memory usage leading to poor
   runtime or ``MemoryError`` if a dictionary were passed that had thousands
   of elements.
+* Fixed issue that would cause ``TaskGraph`` to not recognize a directory
+  that was meant to be ignored and in some cases cause ``Task``s to
+  unnecessarily reexecute.
 
 0.10.2 (2020-12-11)
 -------------------

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1302,7 +1302,6 @@ class Task(object):
             self._target_path_list,
             self._ignore_path_list,
             self._ignore_directories))
-
         LOGGER.debug("file_stat_list: %s", file_stat_list)
         LOGGER.debug("other_arguments: %s", other_arguments)
 
@@ -1533,9 +1532,11 @@ def _filter_non_files(
     elif isinstance(base_value, dict):
         for key in base_value.keys():
             value = base_value[key]
+            scrubbed_dict = {}
             for filter_value in _filter_non_files(
                     value, keep_list, ignore_list, keep_directories):
-                yield (value, filter_value)
+                scrubbed_dict[key] = filter_value
+            yield scrubbed_dict
     elif isinstance(base_value, (list, set, tuple)):
         for value in base_value:
             for filter_value in _filter_non_files(

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1436,8 +1436,7 @@ def _get_file_stats(
 
     Args:
         base_value: any python value. Any file paths in ``base_value``
-            should be "os.path.norm"ed before this function is called.
-            contains filepaths in any nested structure.
+            should be processed with `_normalize_path`.
         hash_algorithm (string): either a hash function id that
             exists in hashlib.algorithms_available, 'exists', or
             'sizetimestamp'. Any paths to actual files in the arguments will be
@@ -1511,17 +1510,20 @@ def _filter_non_files(
             out.
 
     Return:
-        original``base_value`` with any nested file paths for files that
-        exist in the os.exists removed.
+        original ``base_value`` with any nested file paths for files that
+        exist in the os.exists set to ``None``.
 
     """
     if isinstance(base_value, _VALID_PATH_TYPES):
         try:
             norm_path = _normalize_path(base_value)
-            if norm_path not in ignore_list and (norm_path in keep_list or (
-                    os.path.isdir(norm_path) and keep_directories) or
-                    not os.path.isfile(norm_path)):
+            if norm_path not in ignore_list and (
+                    norm_path in keep_list or ((
+                        os.path.isdir(norm_path) and keep_directories) or (
+                        not os.path.isfile(norm_path) and
+                        not os.path.isdir(norm_path)))):
                 return norm_path
+            return None
         except (OSError, ValueError):
             # I ran across a ValueError when one of the os.path functions
             # interpreted the value as a path that was too long.

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1509,6 +1509,22 @@ class TaskGraphTests(unittest.TestCase):
         task_graph.join()
         self.assertTrue(True, 'no memory error so everything is fine')
 
+    def test_filter_non_files(self):
+        """TaskGraph: test internal filter non-files function."""
+        from taskgraph.Task import _filter_non_files
+
+        test_dict = {
+            0: {'one': 0, 'two': 1, 'three': 2},
+            1: {'one': 1, 'two': 2, 'three': 3},
+            2: {'one': 2, 'two': 3, 'three': 4}}
+
+        self.assertEqual(
+            test_dict, _filter_non_files(test_dict, [], [], []))
+
+        test_file_exists = os.path.join(
+            self.workspace, 'exists.txt')
+        pathlib.Path(test_file_exists).touch()
+
 
 def Fail(n_tries, result_path):
     """Create a function that fails after ``n_tries``."""

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1494,6 +1494,21 @@ class TaskGraphTests(unittest.TestCase):
         task_graph._execution_monitor_thread.join(5)
         self.assertFalse(task_graph._execution_monitor_thread.is_alive())
 
+    def test_dictionary_arguments(self):
+        """TaskGraph: test that large dictionary arguments behave well."""
+        task_graph = taskgraph.TaskGraph(self.workspace_dir, -1)
+        dict_arg = {}
+        x = {None: None}
+        for _ in range(10000):
+            dict_arg[_] = x
+
+        def my_op(dict_arg):
+            pass
+        task_graph.add_task(
+            func=my_op, args=(), kwargs={'dict_arg': dict_arg})
+        task_graph.join()
+        self.assertTrue(True, 'no memory error so everything is fine')
+
 
 def Fail(n_tries, result_path):
     """Create a function that fails after ``n_tries``."""

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -23,7 +23,7 @@ MAX_TRY_WAIT_MS = 500
 
 
 def _return_value_once(value):
-    """Returns the value passed to it only once."""
+    """Return the value passed to it only once."""
     if hasattr(_return_value_once, 'executed'):
         raise RuntimeError("this function was called twice")
     _return_value_once.executed = True
@@ -31,7 +31,7 @@ def _return_value_once(value):
 
 
 def _noop_function(**kwargs):
-    """Does nothing except allow kwargs to be passed."""
+    """Do nothing except allow kwargs to be passed."""
     pass
 
 
@@ -1573,9 +1573,6 @@ class TaskGraphTests(unittest.TestCase):
                 [test_file_not_b_exists],
                 False),
             expected_result_dict)
-
-
-
 
 
 def Fail(n_tries, result_path):


### PR DESCRIPTION
This PR fixes #53 by constructing a scrubbed dictionary rather than an incorrect series of dictionary value tuples. Added a test that would have exposed this issue and updates history.