### PR TITLE
appending a character after `` causes rst to fail

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,7 @@ TaskGraph Release History
   runtime or ``MemoryError`` if a dictionary were passed that had thousands
   of elements.
 * Fixed issue that would cause ``TaskGraph`` to not recognize a directory
-  that was meant to be ignored and in some cases cause ``Task``s to
+  that was meant to be ignored and in some cases cause ``Task`` to
   unnecessarily reexecute.
 
 0.10.2 (2020-12-11)


### PR DESCRIPTION
Fixing a single character typo in history