### PR TITLE
fixes #64 ensures that task count does not increase if duplicate tasks are submitted

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@
 TaskGraph Release History
 =========================
 
+Unreleased Changes
+------------------
+* Fixed an issue that could cause the ``TaskGraph`` object to hang if
+  duplicate ``Task`` objects were created.
+
 0.10.3 (2021-01-29)
 -------------------
 * Fixed issue that could cause combinatorial memory usage leading to poor

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -715,6 +715,7 @@ class TaskGraph(object):
                     LOGGER.warning(
                         "A duplicate task was submitted: %s original: %s",
                         new_task, self._task_hash_map[new_task])
+                    self._added_task_count -= 1
                     return duplicate_task
                 disjoint_target_set = (
                     new_task_target_set.symmetric_difference(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1574,6 +1574,20 @@ class TaskGraphTests(unittest.TestCase):
                 False),
             expected_result_dict)
 
+    def test_duplicate_task_hang_on_exit(self):
+        """TaskGraph: ensure duplicate tasks don't cause taskgraph to hang."""
+        task_graph = taskgraph.TaskGraph(self.workspace_dir, 1)
+        target_path = os.path.join(self.workspace_dir, 'target.txt')
+        content = 'test'
+        for _ in range(10):
+            task = task_graph.add_task(
+                func=_create_file,
+                args=(target_path, content),
+                target_path_list=[target_path],
+                task_name='create content')
+        task_graph.join()
+        task_graph.close()
+
 
 def Fail(n_tries, result_path):
     """Create a function that fails after ``n_tries``."""


### PR DESCRIPTION
Decrements `self._added_task_count` if a duplicate task is submitted. This guards against the case that may cause the `TaskGraph` object to hang on termination.

Added a test to cover this even though I couldn't directly reproduce the issue (I think TaskGraph aggressively shuts itself down when the object is deleted and it's hard to reproduce this issue though I have seen it in practice and it's nice to know what was causing it).

Also noted fix in `HISTORY.rst`.

fixes #64 