### PR TITLE
Bugfix/hash algorithm ignored 36

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,12 +12,6 @@ Unreleased Changes
   and to clarify the need for ``if __name__ == '__main__':``
 * Fixed an issue that could cause the ``TaskGraph`` object to hang if
   duplicate ``Task`` objects were created.
-* Removed ``copy_duplicate_artifact`` and ``hardlink_allowed`` parameters
-  and functionality from TaskGraph. This is to address a design error that
-  TaskGraph is not well suited for caching file results to avoid
-  recomputation. Rather than add additional complexity around the limitations
-  of this feature it is being removed to guide a design toward a standalone
-  cache library if needed.
 * Fixed an issue that was causing TaskGraph to ignore a changed
   ``hash_algorithm`` if the TaskGraph was created on one run, was
   deconstructed, then restarted. If the user chose a different hash, TaskGraph

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,26 @@
 TaskGraph Release History
 =========================
 
+Unreleased Changes
+------------------
+* Fixes an issue that causes an ``EOFError`` or ``BrokenPipeError`` to occur
+  when the ``TaskGraph`` terminates.
+* Updated the ``taskgraph`` example in the README for the latest API changes
+  and to clarify the need for ``if __name__ == '__main__':``
+* Fixed an issue that could cause the ``TaskGraph`` object to hang if
+  duplicate ``Task`` objects were created.
+* Removed ``copy_duplicate_artifact`` and ``hardlink_allowed`` parameters
+  and functionality from TaskGraph. This is to address a design error that
+  TaskGraph is not well suited for caching file results to avoid
+  recomputation. Rather than add additional complexity around the limitations
+  of this feature it is being removed to guide a design toward a standalone
+  cache library if needed.
+* Fixed an issue that was causing TaskGraph to ignore a changed
+  ``hash_algorithm`` if the TaskGraph was created on one run, was
+  deconstructed, then restarted. If the user chose a different hash, TaskGraph
+  would use the hash that the target file was originally hashed under rather
+  than the new algorithm.
+
 0.10.3 (2021-01-29)
 -------------------
 * Fixed issue that could cause combinatorial memory usage leading to poor

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1258,7 +1258,6 @@ class Task(object):
         # transient between taskgraph executions and we should expect to
         # run it again.
         if not self._transient_run:
-            LOGGER.debug(result_target_path_stats)
             _execute_sqlite(
                 "INSERT OR REPLACE INTO taskgraph_data VALUES (?, ?, ?)",
                 self._task_database_path, mode='modify',


### PR DESCRIPTION
This PR fixes an issue that was causing TaskGraph to ignore a changed `hash_algorithm` if the TaskGraph was created on one run, was deconstructed, then restarted. If the user chose a different hash, TaskGraph would use the hash that the target file was originally hashed under rather than the new algorithm.

This came up if there was an 'md5' sum but later i changed it to 'exists' because I wanted it to hash faster, but instead it kept hashing at 'md5'. The test case I added covers this. And I fixed this by simply removing how the hash was calculated from the database so it always considers the value of `hash_algorithm` every time it processes `add_task`.

Also updated history.

Fixes #36 