### PR TITLE
Bugfix/76 flaky zerodivisionerror on linux tests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ TaskGraph Release History
 
 Unreleased Changes
 ------------------
+* Fixed an issue where exceptions raised during execution where the task
+  completed before ``TaskGraph.join()`` was called would not be raised.  Now,
+  if a task raises an exception, its exception will always be raised when
+  both ``Task.join()`` and ``TaskGraph.join()`` is called.
 * Fixed an issue where tasks with ``hash_algorithm='sizetimestamp'`` would,
   under certain conditions, fail to re-execute when they should.  This only
   occurred when a graph writing the same amount of , but possibly different,

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -767,18 +767,13 @@ class TaskGraph(object):
         """
         LOGGER.debug("joining taskgraph")
         if self._n_workers < 0:
+            # Join() is meaningless since tasks execute synchronously.
             LOGGER.debug(
                 'n_workers: %s; join is vacuously true' % self._n_workers)
             return True
 
         if self._terminated:
-            LOGGER.debug('Graph was terminated; checking for exceptions')
-            for task_hash, task in self._task_hash_map.items():
-                if task.exception_object:
-                    LOGGER.debug(
-                        'Task %s had an exception; raising %s' % (
-                            task_hash, task.exception_object))
-                    raise task.exception_object
+            LOGGER.debug('Graph already terminated')
             return True
 
         try:

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -766,11 +766,13 @@ class TaskGraph(object):
 
         """
         LOGGER.debug("joining taskgraph")
-        if self._n_workers < 0 or self._terminated:
+        if self._n_workers < 0:
             LOGGER.debug(
-                'workers: %s; terminated? %s' % (
-                    self._n_workers, self._terminated))
+                'n_workers: %s; join is vacuously true' % self._n_workers)
+            return True
 
+        if self._terminated:
+            LOGGER.debug('Graph was terminated; checking for exceptions')
             for task_hash, task in self._task_hash_map.items():
                 if task.exception_object:
                     LOGGER.debug(
@@ -778,6 +780,7 @@ class TaskGraph(object):
                             task_hash, task.exception_object))
                     raise task.exception_object
             return True
+
         try:
             LOGGER.debug("attempting to join threads")
             timedout = False

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -772,10 +772,6 @@ class TaskGraph(object):
                 'n_workers: %s; join is vacuously true' % self._n_workers)
             return True
 
-        if self._terminated:
-            LOGGER.debug('Graph already terminated')
-            return True
-
         try:
             LOGGER.debug("attempting to join threads")
             timedout = False
@@ -790,7 +786,7 @@ class TaskGraph(object):
                         "task %s timed out in graph join", task.task_name)
                     return False
             if self._closed:
-                # Close down the taskgraph
+                # Close down the taskgraph; ok if already terminated
                 self._executor_ready_event.set()
                 self._terminate()
             return True

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -770,6 +770,13 @@ class TaskGraph(object):
             LOGGER.debug(
                 'workers: %s; terminated? %s' % (
                     self._n_workers, self._terminated))
+
+            for task_hash, task in self._task_hash_map.items():
+                if task.exception_object:
+                    LOGGER.debug(
+                        'Task %s had an exception; raising %s' % (
+                            task_hash, task.exception_object))
+                    raise task.exception_object
             return True
         try:
             LOGGER.debug("attempting to join threads")

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -777,6 +777,8 @@ class TaskGraph(object):
             timedout = False
             for task in self._task_hash_map.values():
                 LOGGER.debug("attempting to join task %s", task.task_name)
+                # task.join() will raise any exception that resulted from the
+                # task's execution.
                 timedout = not task.join(timeout)
                 LOGGER.debug("task %s was joined", task.task_name)
                 # if the last task timed out then we want to timeout for all

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -5,7 +5,6 @@ import hashlib
 import inspect
 import logging
 import logging.handlers
-import math
 import multiprocessing
 import multiprocessing.pool
 import os
@@ -768,6 +767,9 @@ class TaskGraph(object):
         """
         LOGGER.debug("joining taskgraph")
         if self._n_workers < 0 or self._terminated:
+            LOGGER.debug(
+                'workers: %s; terminated? %s' % (
+                    self._n_workers, self._terminated))
             return True
         try:
             LOGGER.debug("attempting to join threads")

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -91,12 +91,6 @@ def _div_by_zero():
     return 1/0
 
 
-def _div_by_zero_with_sleep():
-    """Divide by zero to raise an exception."""
-    time.sleep(1)
-    return 1/0
-
-
 def _create_file(target_path, content):
     """Create a file with contents."""
     with open(target_path, 'w') as target_file:
@@ -480,7 +474,7 @@ class TaskGraphTests(unittest.TestCase):
         task_graph = taskgraph.TaskGraph(self.workspace_dir, 1)
 
         _ = task_graph.add_task(
-            func=_div_by_zero_with_sleep, task_name='test_broken_task')
+            func=_div_by_zero, task_name='test_broken_task')
         task_graph.close()
         with self.assertRaises(ZeroDivisionError):
             task_graph.join()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1254,7 +1254,8 @@ class TaskGraphTests(unittest.TestCase):
                         transient_run=True,
                         store_result=True,
                         args=(expected_value,),
-                        task_name='expected error {iteration_id}')
+                        task_name=f'expected error {iteration_id}')
+
                     value = value_task.get()
 
                 with self.assertRaises(RuntimeError):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -4,8 +4,8 @@ import logging
 import logging.handlers
 import multiprocessing
 import os
-import pickle
 import pathlib
+import pickle
 import re
 import rstcheck
 import shutil
@@ -88,6 +88,12 @@ def _sum_lists_from_disk(list_a_path, list_b_path, target_path):
 
 def _div_by_zero():
     """Divide by zero to raise an exception."""
+    return 1/0
+
+
+def _div_by_zero_with_sleep():
+    """Divide by zero to raise an exception."""
+    time.sleep(1)
     return 1/0
 
 
@@ -472,8 +478,9 @@ class TaskGraphTests(unittest.TestCase):
     def test_broken_task(self):
         """TaskGraph: Test that a task with an exception won't hang."""
         task_graph = taskgraph.TaskGraph(self.workspace_dir, 1)
+
         _ = task_graph.add_task(
-            func=_div_by_zero, task_name='test_broken_task')
+            func=_div_by_zero_with_sleep, task_name='test_broken_task')
         task_graph.close()
         with self.assertRaises(ZeroDivisionError):
             task_graph.join()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -479,7 +479,9 @@ class TaskGraphTests(unittest.TestCase):
             _ = broken_task.join()
 
         task_graph.close()
-        task_graph.join()
+
+        with self.assertRaises(ZeroDivisionError):
+            task_graph.join()
 
     def test_broken_task_chain(self):
         """TaskGraph: test dependent tasks fail on ancestor fail."""
@@ -1243,6 +1245,8 @@ class TaskGraphTests(unittest.TestCase):
                     task_name='first re-run transient')
                 value = value_task.get()
                 self.assertEqual(value, expected_value)
+                task_graph.close()
+                task_graph.join()
             else:
                 with self.assertRaises(RuntimeError):
                     value_task = task_graph.add_task(
@@ -1253,8 +1257,9 @@ class TaskGraphTests(unittest.TestCase):
                         task_name='expected error {iteration_id}')
                     value = value_task.get()
 
-            task_graph.close()
-            task_graph.join()
+                with self.assertRaises(RuntimeError):
+                    task_graph.join()
+
             task_graph = None
 
     def test_malformed_taskgraph_database(self):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -473,11 +473,13 @@ class TaskGraphTests(unittest.TestCase):
         """TaskGraph: Test that a task with an exception won't hang."""
         task_graph = taskgraph.TaskGraph(self.workspace_dir, 1)
 
-        _ = task_graph.add_task(
+        broken_task = task_graph.add_task(
             func=_div_by_zero, task_name='test_broken_task')
-        task_graph.close()
         with self.assertRaises(ZeroDivisionError):
-            task_graph.join()
+            _ = broken_task.join()
+
+        task_graph.close()
+        task_graph.join()
 
     def test_broken_task_chain(self):
         """TaskGraph: test dependent tasks fail on ancestor fail."""
@@ -1190,7 +1192,6 @@ class TaskGraphTests(unittest.TestCase):
         with open(target_file_path, 'r') as target_file:
             self.assertEqual(target_file.read(), 'content')
 
-
     def test_return_value_no_record(self):
         """TaskGraph: test  ``get`` raises exception if not set to record."""
         task_graph = taskgraph.TaskGraph(self.workspace_dir, -1)
@@ -1239,7 +1240,7 @@ class TaskGraphTests(unittest.TestCase):
                     transient_run=True,
                     store_result=True,
                     args=(expected_value,),
-                    task_name=f'first re-run transient')
+                    task_name='first re-run transient')
                 value = value_task.get()
                 self.assertEqual(value, expected_value)
             else:
@@ -1249,7 +1250,7 @@ class TaskGraphTests(unittest.TestCase):
                         transient_run=True,
                         store_result=True,
                         args=(expected_value,),
-                        task_name=f'expected error {iteration_id}')
+                        task_name='expected error {iteration_id}')
                     value = value_task.get()
 
             task_graph.close()
@@ -1301,7 +1302,7 @@ class TaskGraphTests(unittest.TestCase):
                 'task_reexecution_hash', 'target_path_stats', 'result']
             connection = sqlite3.connect(database_path)
             cursor = connection.cursor()
-            cursor.execute(f'PRAGMA table_info(taskgraph_data)')
+            cursor.execute('PRAGMA table_info(taskgraph_data)')
             result = list(cursor.fetchall())
             cursor.close()
             connection.commit()


### PR DESCRIPTION
This PR addresses a flaky `ZeroDivisionError` that would occasionally be encountered on our ubuntu/psutil GHA tests (all python versions).  The root cause was that the graph (where `n_workers>=1`) could get into a state where:

1. A task is added
2. The task is started
3. The task fails, causing the graph to be terminated
4. Join is called sometime after graph termination, resulting in the exception passing without being propagated.

This silent passing of exceptions under these circumstances was inconsistent with how `TaskGraph.join()` was operating when there were incomplete tasks (some of which might raise an exception that _would_ propagate to the caller).  This PR changes this behavior to cause `TaskGraph.join()` to propagate the first exception encountered when the graph is joined.

Because of this change in behavior, it's possible for an exception to be raised twice: once when the erroring task is joined and the same exception again is raised when the graph is joined.  I think this is reasonable and more predictable behavior than silently passing an exception.

There's also some light linting, mostly of f-strings.

Fixes #76 

PS: Since this is a subtle but notable change in the behavior of TaskGraph, I tried running the InVEST test suite against this build just to make sure this wouldn't break everything.  Here are the test results (currently all passing): https://github.com/phargogh/invest/runs/3750631610?check_suite_focus=true