### PR TITLE
Test taskgraph against Python 3.10

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-rc2"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-rc2"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-rc.2"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ TaskGraph Release History
 
 Unreleased Changes
 ------------------
+* Testing against python 3.10 in github actions and officially noting support
+  for 3.10 in ``setup.py``.
 * Testing against python 3.9 in github actions and noting support in
   ``setup.py``.
 * Fixed an issue where exceptions raised during execution where the task

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: BSD License'
     ])

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -416,7 +416,7 @@ class TaskGraph(object):
             if self._terminated:
                 LOGGER.debug(
                     "taskgraph is terminated, ending %s",
-                    threading.currentThread())
+                    threading.current_thread())
                 break
             task = None
             try:
@@ -449,7 +449,7 @@ class TaskGraph(object):
                             LOGGER.warning('worker pool was already closed')
                     LOGGER.debug(
                         "no tasks are pending and taskgraph closed, normally "
-                        "terminating executor %s." % threading.currentThread())
+                        "terminating executor %s." % threading.current_thread())
                     break
                 else:
                     # there's still the possibility for work to be added or

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39}-{base,psutil}
+envlist = {py36,py37,py38,py39,py310}-{base,psutil}
 
 [gh-actions]
 # Allows us to use tox configuration to manage our tests, but still run on
@@ -10,6 +10,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 commands =


### PR DESCRIPTION
This PR adds support for python 3.10, noting the change in setup.py.

There was also a new `deprecationWarning` that cropped up, so I've addressed that.

RE:#78