### PR TITLE
Update python versions supported (-3.6, +3.11)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -31,7 +31,7 @@ jobs:
           python -m pip install --upgrade pip
           # See this comment about the importlib_metadata constraint:
           # https://github.com/python/importlib_metadata/issues/406#issuecomment-1264666048
-          pip install tox tox-gh-actions flake8 "importlib_metadata<5"
+          pip install tox tox-gh-actions flake8 "importlib_metadata<5" rstcheck
 
       - name: Lint with flake8
         run: |

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -29,7 +29,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions flake8
+          # See this comment about the importlib_metadata constraint:
+          # https://github.com/python/importlib_metadata/issues/406#issuecomment-1264666048
+          pip install tox tox-gh-actions flake8 "importlib_metadata<5"
 
       - name: Lint with flake8
         run: |

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,12 @@
 TaskGraph Release History
 =========================
 
-.. Unreleased Changes
+Unreleased Changes
+------------------
+* Python 3.6 has reached end-of-life and is no longer maintained, so it has
+  been removed from the automated tests.
+* Python 3.11 has been released, so ``taskgraph`` is now tested against this
+  new version of the language.
 
 0.11.0 (2021-10-12)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 """taskgraph setup.py."""
 from setuptools import setup
 
-
 _REQUIREMENTS = [
     x for x in open('requirements.txt').read().split('\n')
     if not x.startswith('#') and len(x) > 0]
@@ -35,10 +34,10 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft',
         'Operating System :: POSIX',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'License :: OSI Approved :: BSD License'
     ])

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -7,9 +7,9 @@ import os
 import pathlib
 import pickle
 import re
-import rstcheck
 import shutil
 import sqlite3
+import subprocess
 import tempfile
 import time
 import unittest
@@ -164,6 +164,7 @@ class TaskGraphTests(unittest.TestCase):
         """TaskGraph: verify we can load the version."""
         try:
             import taskgraph
+
             # Verifies that there's a version attribute and it has a value.
             self.assertTrue(len(taskgraph.__version__) > 0)
         except Exception:
@@ -899,6 +900,7 @@ class TaskGraphTests(unittest.TestCase):
     def test_very_long_string(self):
         """TaskGraph: ensure that long strings don't case an OSError."""
         from taskgraph.Task import _get_file_stats
+
         # this is a list with two super long strings to try to trick some
         # os function into thinking it's a path.
         base_value = [
@@ -1441,8 +1443,7 @@ class TaskGraphTests(unittest.TestCase):
         # ensure there are no errors when checking the history file
         history_filepath = os.path.join(
             os.path.dirname(__file__), '..', 'HISTORY.rst')
-        self.assertEqual(
-            list(rstcheck.check(open(history_filepath, 'r').read())), [])
+        subprocess.check_call(['rstcheck', history_filepath])
 
     def test_mtime_mismatch(self):
         """TaskGraph: ensure re-run when file mtimes don't match.

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -433,10 +433,12 @@ class TaskGraphTests(unittest.TestCase):
         # was a duplicate
         database_path = os.path.join(
             self.workspace_dir, taskgraph._TASKGRAPH_DATABASE_FILENAME)
-        with sqlite3.connect(database_path) as conn:
+        conn = sqlite3.connect(database_path)
+        with conn:
             cursor = conn.cursor()
             cursor.execute("SELECT * FROM taskgraph_data")
             result = cursor.fetchall()
+        conn.close()
         self.assertEqual(len(result), 4)
 
     def test_task_broken_chain(self):
@@ -527,10 +529,13 @@ class TaskGraphTests(unittest.TestCase):
         # we shouldn't have anything in the database
         database_path = os.path.join(
             self.workspace_dir, taskgraph._TASKGRAPH_DATABASE_FILENAME)
-        with sqlite3.connect(database_path) as conn:
+
+        conn = sqlite3.connect(database_path)
+        with conn:
             cursor = conn.cursor()
             cursor.executescript("SELECT * FROM taskgraph_data")
             result = cursor.fetchall()
+        conn.close()
         self.assertEqual(len(result), 0)
 
     def test_closed_graph(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,py310}-{base,psutil}
+envlist = {py37,py38,py39,py310,py311}-{base,psutil}
 
 [gh-actions]
 # Allows us to use tox configuration to manage our tests, but still run on
@@ -11,6 +11,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 commands =


### PR DESCRIPTION
This PR updates the officially-supported python versions and does a couple other minor things to update how the tests are run.

Fixes #88 