### PR TITLE
Test on 3.12, drop support for 3.7

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,9 +6,14 @@ TaskGraph Release History
 
 Unreleased Changes
 ------------------
+* Adding ``pyproject.toml`` for our build definitions.
 * Python 3.6 has reached end-of-life and is no longer maintained, so it has
   been removed from the automated tests.
+* Python 3.7 has reached end-of-life and is no longer maintained, so it has
+  been removed from automated tests.
 * Python 3.11 has been released, so ``taskgraph`` is now tested against this
+  new version of the language.
+* Python 3.12 has been released, so ``taskgraph`` is now tested against this
   new version of the language.
 
 0.11.0 (2021-10-12)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License"
 ]
 # the version is provided dynamically by setuptools_scm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = {file = "LICENSE.txt"}
 maintainers = [
     {name = "Natural Capital Project Software Team"}
 ]
-keywords = "parallel multiprocessing distributed computing"
+keywords = ["parallel", "multiprocessing", "distributed", "computing"]
 classifiers = [
     "Intended Audience :: Developers",
     "Topic :: System :: Distributed Computing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+name = "taskgraph"
+description = "Parallel task graph framework"
+readme = "README.rst"
+requires-python = ">=3.6"
+license = {file = "LICENSE.txt"}
+maintainers = [
+    {name = "Natural Capital Project Software Team"}
+]
+keywords = "parallel multiprocessing distributed computing"
+classifiers = [
+    "Intended Audience :: Developers",
+    "Topic :: System :: Distributed Computing",
+    "Development Status :: 5 - Production/Stable",
+    "Natural Language :: English",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.11",
+    "License :: OSI Approved :: BSD License"
+]
+# the version is provided dynamically by setuptools_scm
+# `dependencies` and `optional-dependencies` are provided by setuptools
+# using the corresponding setup args `install_requires` and `extras_require`
+dynamic = ["version", "dependencies", "optional-dependencies"]
+
+[build-system]
+requires = [
+    'wheel', 'setuptools_scm>=8.0'
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "node-and-date"

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+
         'License :: OSI Approved :: BSD License'
     ])

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,10 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft',
         'Operating System :: POSIX',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.11',
         'License :: OSI Approved :: BSD License'
     ])

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 commands =


### PR DESCRIPTION
No changes needed, but I did add a `pyproject.toml` to the project to update for the latest build standards.

Fixes #95 