### PR TITLE
Updating version fetching to no longer use `pkg_resources`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@
 TaskGraph Release History
 =========================
 
+Unreleased Changes
+------------------
+* Using ``importlib.metadata`` or ``importlib_metadata``, depending on the
+  python version, to read the version from package metadata.  This is in
+  response to ``pkg_resources`` being deprecated.
+  (`#100 <https://github.com/natcap/taskgraph/issues/100>`_)
+
 0.11.1 (2023-10-27)
 -------------------
 * Adding ``pyproject.toml`` for our build definitions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 # taskgraph to work as expected.
 
 retrying>=1.3.0
+importlib_metadata  # technically only required on python < 3.8; easier to install with conda across all versions

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -1,5 +1,4 @@
 """Task graph framework."""
-from pkg_resources import get_distribution
 import collections
 import hashlib
 import inspect
@@ -15,10 +14,21 @@ import queue
 import sqlite3
 import threading
 import time
+try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version
+except ImportError:
+    # importlib.metadata added to stdlib in 3.8
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version
 
 import retrying
 
-__version__ = get_distribution('taskgraph').version
+try:
+    __version__ = version('taskgraph')
+except PackageNotFoundError:
+    # package is not installed; no metadata available
+    pass
 
 
 _VALID_PATH_TYPES = (str, pathlib.PurePath)


### PR DESCRIPTION
Using `importlib.metadata` or `importlib_metadata` depending on the python version to get version metadata.

Fixes #100 