### PR TITLE
Monitor processes in the Pool for process changes

### DIFF
--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -101,19 +101,6 @@ def _null_func():
     return None
 
 
-def _initialize_process_pool(logging_queue):
-    """A function to chain together multiple initialization functions.
-
-    Args:
-        logging_queue (multiprocessing.Queue): The queue to use for passing
-            log records back to the main process.
-
-    Returns:
-        ``None``
-    """
-    _initialize_logging_to_queue(logging_queue)
-
-
 def _initialize_logging_to_queue(logging_queue):
     """Add a synchronized queue to a new process.
 
@@ -404,7 +391,7 @@ class TaskGraph(object):
         if n_workers > 0:
             self._logging_queue = multiprocessing.Queue()
             self._worker_pool = NonDaemonicPool(
-                n_workers, initializer=_initialize_process_pool,
+                n_workers, initializer=_initialize_logging_to_queue,
                 initargs=(self._logging_queue,))
             self._logging_monitor_thread = threading.Thread(
                 target=_logging_queue_monitor,

--- a/taskgraph/Task.py
+++ b/taskgraph/Task.py
@@ -23,7 +23,6 @@ except ImportError:
     from importlib_metadata import PackageNotFoundError
     from importlib_metadata import version
 
-import psutil
 import retrying
 
 try:
@@ -36,14 +35,19 @@ except PackageNotFoundError:
 _VALID_PATH_TYPES = (str, pathlib.PurePath)
 _TASKGRAPH_DATABASE_FILENAME = 'taskgraph_data.db'
 
-if psutil.WINDOWS:
-    # Windows' scheduler doesn't use POSIX niceness.
-    PROCESS_LOW_PRIORITY = psutil.BELOW_NORMAL_PRIORITY_CLASS
-else:
-    # On POSIX, use system niceness.
-    # -20 is high priority, 0 is normal priority, 19 is low priority.
-    # 10 here is an arbitrary selection that's probably nice enough.
-    PROCESS_LOW_PRIORITY = 10
+try:
+    import psutil
+    HAS_PSUTIL = True
+    if psutil.WINDOWS:
+        # Windows' scheduler doesn't use POSIX niceness.
+        PROCESS_LOW_PRIORITY = psutil.BELOW_NORMAL_PRIORITY_CLASS
+    else:
+        # On POSIX, use system niceness.
+        # -20 is high priority, 0 is normal priority, 19 is low priority.
+        # 10 here is an arbitrary selection that's probably nice enough.
+        PROCESS_LOW_PRIORITY = 10
+except ImportError:
+    HAS_PSUTIL = False
 
 LOGGER = logging.getLogger(__name__)
 _MAX_TIMEOUT = 5.0  # amount of time to wait for threads to terminate
@@ -416,16 +420,17 @@ class TaskGraph(object):
             self._process_pool_monitor_thread.daemon = True
             self._process_pool_monitor_thread.start()
 
-            parent = psutil.Process()
-            parent.nice(PROCESS_LOW_PRIORITY)
-            for child in parent.children():
-                try:
-                    child.nice(PROCESS_LOW_PRIORITY)
-                except psutil.NoSuchProcess:
-                    LOGGER.warning(
-                        "NoSuchProcess exception encountered when trying "
-                        "to nice %s. This might be a bug in `psutil` so "
-                        "it should be okay to ignore.")
+            if HAS_PSUTIL:
+                parent = psutil.Process()
+                parent.nice(PROCESS_LOW_PRIORITY)
+                for child in parent.children():
+                    try:
+                        child.nice(PROCESS_LOW_PRIORITY)
+                    except psutil.NoSuchProcess:
+                        LOGGER.warning(
+                            "NoSuchProcess exception encountered when trying "
+                            "to nice %s. This might be a bug in `psutil` so "
+                            "it should be okay to ignore.")
 
     def __del__(self):
         """Ensure all threads have been joined for cleanup."""

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -150,7 +150,8 @@ def _kill_current_process():
         raise AssertionError(
             "This function is only supposed to be called in a subprocess")
 
-    os.kill(os.getpid(), signal.SIGKILL)
+    # Signal.SIGTERM works on both *NIX and Windows.
+    os.kill(os.getpid(), signal.SIGTERM)
 
 
 class TaskGraphTests(unittest.TestCase):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -8,6 +8,7 @@ import pathlib
 import pickle
 import re
 import shutil
+import signal
 import sqlite3
 import subprocess
 import tempfile
@@ -138,6 +139,18 @@ def _log_from_another_process(logger_name, log_message):
     """
     logger = logging.getLogger(logger_name)
     logger.info(log_message)
+
+
+def _kill_current_process():
+    """Kill the current process.
+
+    Must be run within a taskgraph task process.
+    """
+    if __name__ == '__main__':
+        raise AssertionError(
+            "This function is only supposed to be called in a subprocess")
+
+    os.kill(os.getpid(), signal.SIGKILL)
 
 
 class TaskGraphTests(unittest.TestCase):
@@ -1479,6 +1492,20 @@ class TaskGraphTests(unittest.TestCase):
 
         with open(target_path) as target_file:
             self.assertEqual(target_file.read(), content)
+
+    def test_multiprocessing_deadlock(self):
+        """Verify that the graph is shut down in case of deadlock.
+
+        This test will deadlock if the functionality it is testing for (graph
+        shutdown when a task process is killed) is not available.
+
+        See https://github.com/natcap/taskgraph/issues/109
+        """
+        task_graph = taskgraph.TaskGraph(self.workspace_dir, n_workers=1)
+        task = task_graph.add_task(_kill_current_process)
+
+        task_graph.join()
+        task_graph.close()
 
 
 def Fail(n_tries, result_path):


### PR DESCRIPTION
This PR monitors changes to the PIDs of workers in the TaskGraph's `multiprocessing.Pool`, so that if a worker is terminated for any reason, the whole graph is terminated and we log an error message.  This avoids a deadlock resulting from events never being triggered that would allow task callables to execute.