### PR TITLE
NatCap Alliance name update

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,9 +4,11 @@
 TaskGraph Release History
 =========================
 
-..
-   Unreleased Changes
-   ------------------
+Unreleased Changes
+------------------
+* The Natural Capital Project changed its name to the Natural Capital Alliance.
+  References to the old name have been updated to reflect this change.
+  (`#113 <https://github.com/natcap/taskgraph/issues/113>`_)
 
 0.11.2 (2025-05-21)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.rst"
 requires-python = ">=3.6"
 license = {file = "LICENSE.txt"}
 maintainers = [
-    {name = "Natural Capital Project Software Team"}
+    {name = "Natural Capital Alliance Software Team"}
 ]
 keywords = ["parallel", "multiprocessing", "distributed", "computing"]
 classifiers = [


### PR DESCRIPTION
Fixes #113 

Looks like the only references to the Natural Capital Project are in `pyproject.toml` and `LICENSE.txt`. This PR updates the former but not the latter; there's a separate issue for that, as there may be additional changes beyond just the name.