### PR TITLE
Update the test matrix for currently-supported python

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        # Testing against all supported versions of CPython.
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,10 @@ Unreleased Changes
 * The Natural Capital Project changed its name to the Natural Capital Alliance.
   References to the old name have been updated to reflect this change.
   (`#113 <https://github.com/natcap/taskgraph/issues/113>`_)
+* GitHub Actions-based tests are now running against CPython 3.13 and 3.14, and
+  no longer running against 3.8 and 3.9.  All currently-supported versions of
+  CPython are in the test matrix.
+  (`#111 <https://github.com/natcap/taskgraph/issues/111>`_)
 
 0.11.2 (2025-05-21)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft",
     "Operating System :: POSIX",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: BSD License"
 ]
 # the version is provided dynamically by setuptools_scm

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {y310,py311,py312,py313,py314}-{base,psutil}
+envlist = {py310,py311,py312,py313,py314}-{base,psutil}
 
 [gh-actions]
 # Allows us to use tox configuration to manage our tests, but still run on

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,16 @@
 [tox]
-envlist = {py37,py38,py39,py310,py311}-{base,psutil}
+envlist = {y310,py311,py312,py313,py314}-{base,psutil}
 
 [gh-actions]
 # Allows us to use tox configuration to manage our tests, but still run on
 # github actions in the GHA matrix job matrix with GHA-managed python.
 # Requires tox-gh-actions package to run.
 python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 commands =


### PR DESCRIPTION
This PR adds CPython 3.13, 3.14 (non-free-threaded, see #118 ) to the github actions test matrix and drops CPython 3.8, 3.9.  This reflects the current state of which CPython versions are supported. RE:#111